### PR TITLE
[Server] feature : 디렉토리 구조 설정 및 소셜로그인 구현

### DIFF
--- a/server/src/main/java/shinhan/mohaemoyong/server/ServerApplication.java
+++ b/server/src/main/java/shinhan/mohaemoyong/server/ServerApplication.java
@@ -2,8 +2,10 @@ package shinhan.mohaemoyong.server;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.context.properties.ConfigurationPropertiesScan;
 
 @SpringBootApplication
+@ConfigurationPropertiesScan
 public class ServerApplication {
 
 	public static void main(String[] args) {

--- a/server/src/main/java/shinhan/mohaemoyong/server/controller/UserController.java
+++ b/server/src/main/java/shinhan/mohaemoyong/server/controller/UserController.java
@@ -1,0 +1,27 @@
+package shinhan.mohaemoyong.server.controller;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+import shinhan.mohaemoyong.server.exception.ResourceNotFoundException;
+import shinhan.mohaemoyong.server.model.entity.User;
+import shinhan.mohaemoyong.server.oauth2.security.CurrentUser;
+import shinhan.mohaemoyong.server.oauth2.security.UserPrincipal;
+import shinhan.mohaemoyong.server.repository.UserRepository;
+
+@RestController
+public class UserController {
+
+    @Autowired
+    private UserRepository userRepository;
+
+    // 실사용 api X, 소셜로그인 테스트용
+    // 추후에 리팩토링 필요 : dto return
+    @GetMapping("/user/me")
+    @PreAuthorize("hasRole('USER')")
+    public User getCurrentUser(@CurrentUser UserPrincipal userPrincipal) {
+        return userRepository.findById(userPrincipal.getId())
+                .orElseThrow(() -> new ResourceNotFoundException("User", "id", userPrincipal.getId()));
+    }
+}

--- a/server/src/main/java/shinhan/mohaemoyong/server/exception/BadRequestException.java
+++ b/server/src/main/java/shinhan/mohaemoyong/server/exception/BadRequestException.java
@@ -1,0 +1,15 @@
+package shinhan.mohaemoyong.server.exception;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.ResponseStatus;
+
+@ResponseStatus(HttpStatus.BAD_REQUEST)
+public class BadRequestException extends RuntimeException {
+    public BadRequestException(String message) {
+        super(message);
+    }
+
+    public BadRequestException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/server/src/main/java/shinhan/mohaemoyong/server/exception/OAuth2AuthenticationProcessingException.java
+++ b/server/src/main/java/shinhan/mohaemoyong/server/exception/OAuth2AuthenticationProcessingException.java
@@ -1,0 +1,13 @@
+package shinhan.mohaemoyong.server.exception;
+
+import org.springframework.security.core.AuthenticationException;
+
+public class OAuth2AuthenticationProcessingException extends AuthenticationException {
+    public OAuth2AuthenticationProcessingException(String msg, Throwable t) {
+        super(msg, t);
+    }
+
+    public OAuth2AuthenticationProcessingException(String msg) {
+        super(msg);
+    }
+}

--- a/server/src/main/java/shinhan/mohaemoyong/server/exception/ResourceNotFoundException.java
+++ b/server/src/main/java/shinhan/mohaemoyong/server/exception/ResourceNotFoundException.java
@@ -1,0 +1,30 @@
+package shinhan.mohaemoyong.server.exception;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.ResponseStatus;
+
+@ResponseStatus(HttpStatus.NOT_FOUND)
+public class ResourceNotFoundException extends RuntimeException {
+    private String resourceName;
+    private String fieldName;
+    private Object fieldValue;
+
+    public ResourceNotFoundException(String resourceName, String fieldName, Object fieldValue) {
+        super(String.format("%s not found with %s : '%s'", resourceName, fieldName, fieldValue));
+        this.resourceName = resourceName;
+        this.fieldName = fieldName;
+        this.fieldValue = fieldValue;
+    }
+
+    public String getResourceName() {
+        return resourceName;
+    }
+
+    public String getFieldName() {
+        return fieldName;
+    }
+
+    public Object getFieldValue() {
+        return fieldValue;
+    }
+}

--- a/server/src/main/java/shinhan/mohaemoyong/server/model/entity/User.java
+++ b/server/src/main/java/shinhan/mohaemoyong/server/model/entity/User.java
@@ -1,0 +1,40 @@
+package shinhan.mohaemoyong.server.model.entity;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import jakarta.persistence.*;
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotNull;
+import lombok.Getter;
+import lombok.Setter;
+import shinhan.mohaemoyong.server.oauth2.AuthProvider;
+
+
+@Entity
+@Getter @Setter
+@Table(name = "users", uniqueConstraints = {@UniqueConstraint(columnNames = "email")})
+public class User {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false)
+    private String name;
+
+    @Email
+    @Column(nullable = false)
+    private String email;
+
+    private String imageUrl;
+
+    @Column(nullable = false)
+    private Boolean emailVerified = false;
+
+    @JsonIgnore
+    private String password;
+
+    @NotNull
+    @Enumerated(EnumType.STRING)
+    private AuthProvider provider;
+
+    private String providerId;
+}

--- a/server/src/main/java/shinhan/mohaemoyong/server/oauth2/AuthProvider.java
+++ b/server/src/main/java/shinhan/mohaemoyong/server/oauth2/AuthProvider.java
@@ -1,0 +1,8 @@
+package shinhan.mohaemoyong.server.oauth2;
+
+public enum AuthProvider {
+   // 우선 카카오만 소셜
+    kakao,
+    local
+
+}

--- a/server/src/main/java/shinhan/mohaemoyong/server/oauth2/config/AppProperties.java
+++ b/server/src/main/java/shinhan/mohaemoyong/server/oauth2/config/AppProperties.java
@@ -1,0 +1,54 @@
+package shinhan.mohaemoyong.server.oauth2.config;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@ConfigurationProperties(prefix = "app")
+public class AppProperties {
+    private final Auth auth = new Auth();
+    private final OAuth2 oauth2 = new OAuth2();
+
+    public static class Auth {
+        private String tokenSecret;
+        private long tokenExpirationMsec;
+
+        public String getTokenSecret() {
+            return tokenSecret;
+        }
+
+        public void setTokenSecret(String tokenSecret) {
+            this.tokenSecret = tokenSecret;
+        }
+
+        public long getTokenExpirationMsec() {
+            return tokenExpirationMsec;
+        }
+
+        public void setTokenExpirationMsec(long tokenExpirationMsec) {
+            this.tokenExpirationMsec = tokenExpirationMsec;
+        }
+    }
+
+    public static final class OAuth2 {
+        private List<String> authorizedRedirectUris = new ArrayList<>();
+
+        public List<String> getAuthorizedRedirectUris() {
+            return authorizedRedirectUris;
+        }
+
+        public OAuth2 authorizedRedirectUris(List<String> authorizedRedirectUris) {
+            this.authorizedRedirectUris = authorizedRedirectUris;
+            return this;
+        }
+    }
+
+    public Auth getAuth() {
+        return auth;
+    }
+
+    public OAuth2 getOauth2() {
+        return oauth2;
+    }
+}

--- a/server/src/main/java/shinhan/mohaemoyong/server/oauth2/config/SecurityConfig.java
+++ b/server/src/main/java/shinhan/mohaemoyong/server/oauth2/config/SecurityConfig.java
@@ -1,0 +1,130 @@
+package shinhan.mohaemoyong.server.oauth2.config;
+
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.config.BeanIds;
+import org.springframework.security.config.annotation.authentication.configuration.AuthenticationConfiguration;
+import org.springframework.security.config.annotation.method.configuration.EnableGlobalMethodSecurity;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+import shinhan.mohaemoyong.server.oauth2.security.CustomUserDetailsService;
+import shinhan.mohaemoyong.server.oauth2.security.RestAuthenticationEntryPoint;
+import shinhan.mohaemoyong.server.oauth2.security.TokenAuthenticationFilter;
+import shinhan.mohaemoyong.server.oauth2.security.oauth2.CustomOAuth2UserService;
+import shinhan.mohaemoyong.server.oauth2.security.oauth2.HttpCookieOAuth2AuthorizationRequestRepository;
+import shinhan.mohaemoyong.server.oauth2.security.oauth2.OAuth2AuthenticationFailureHandler;
+import shinhan.mohaemoyong.server.oauth2.security.oauth2.OAuth2AuthenticationSuccessHandler;
+
+
+@Configuration
+@EnableWebSecurity
+@EnableGlobalMethodSecurity(
+        securedEnabled = true,
+        jsr250Enabled = true,
+        prePostEnabled = true
+)
+public class SecurityConfig {
+
+    @Autowired
+    private CustomUserDetailsService customUserDetailsService;
+
+    @Autowired
+    private CustomOAuth2UserService customOAuth2UserService;
+
+    @Autowired
+    private OAuth2AuthenticationSuccessHandler oAuth2AuthenticationSuccessHandler;
+
+    @Autowired
+    private OAuth2AuthenticationFailureHandler oAuth2AuthenticationFailureHandler;
+
+    @Autowired
+    private HttpCookieOAuth2AuthorizationRequestRepository httpCookieOAuth2AuthorizationRequestRepository;
+
+    @Bean
+    public TokenAuthenticationFilter tokenAuthenticationFilter() {
+        return new TokenAuthenticationFilter();
+    }
+
+    /*
+      By default, Spring OAuth2 uses HttpSessionOAuth2AuthorizationRequestRepository to save
+      the authorization request. But, since our service is stateless, we can't save it in
+      the session. We'll save the request in a Base64 encoded cookie instead.
+    */
+    @Bean
+    public HttpCookieOAuth2AuthorizationRequestRepository cookieAuthorizationRequestRepository() {
+        return new HttpCookieOAuth2AuthorizationRequestRepository();
+    }
+
+    @Bean
+    public PasswordEncoder passwordEncoder() {
+        return new BCryptPasswordEncoder();
+    }
+
+
+    @Bean(BeanIds.AUTHENTICATION_MANAGER)
+    public AuthenticationManager authenticationManager(AuthenticationConfiguration authenticationConfiguration) throws Exception {
+        return authenticationConfiguration.getAuthenticationManager();
+    }
+
+    @Bean
+    protected SecurityFilterChain filterChain (HttpSecurity http) throws Exception {
+        http
+                .cors()
+                    .and()
+                .sessionManagement()
+                    .sessionCreationPolicy(SessionCreationPolicy.STATELESS)
+                    .and()
+                .csrf()
+                    .disable()
+                .formLogin()
+                    .disable()
+                .httpBasic()
+                    .disable()
+                .exceptionHandling()
+                    .authenticationEntryPoint(new RestAuthenticationEntryPoint())
+                    .and()
+                .authorizeRequests()
+                    .requestMatchers("/",
+                        "/error",
+                        "/favicon.ico",
+                        "/**.png",
+                        "/**.gif",
+                        "/**.svg",
+                        "/**.jpg",
+                        "/**.html",
+                        "/**.css",
+                        "/**.js")
+                        .permitAll()
+                    .requestMatchers("/auth/**", "/oauth2/**")
+                        .permitAll()
+                    .anyRequest()
+                        .authenticated()
+                    .and()
+                .oauth2Login()
+                    .authorizationEndpoint()
+                        .baseUri("/oauth2/authorization")
+                        .authorizationRequestRepository(cookieAuthorizationRequestRepository())
+                        .and()
+                    .redirectionEndpoint()
+                        .baseUri("/oauth2/callback/*")
+                        .and()
+                    .userInfoEndpoint()
+                        .userService(customOAuth2UserService) //로그인 후 후처리
+                        .and()
+                    .successHandler(oAuth2AuthenticationSuccessHandler)
+                    .failureHandler(oAuth2AuthenticationFailureHandler);
+
+        // Add our custom Token based authentication filter
+        http.addFilterBefore(tokenAuthenticationFilter(), UsernamePasswordAuthenticationFilter.class);
+
+        return http.build();
+    }
+}

--- a/server/src/main/java/shinhan/mohaemoyong/server/oauth2/controller/AuthController.java
+++ b/server/src/main/java/shinhan/mohaemoyong/server/oauth2/controller/AuthController.java
@@ -1,0 +1,86 @@
+package shinhan.mohaemoyong.server.oauth2.controller;
+
+
+import jakarta.validation.Valid;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.servlet.support.ServletUriComponentsBuilder;
+import shinhan.mohaemoyong.server.exception.BadRequestException;
+import shinhan.mohaemoyong.server.model.entity.User;
+import shinhan.mohaemoyong.server.oauth2.AuthProvider;
+import shinhan.mohaemoyong.server.oauth2.payload.ApiResponse;
+import shinhan.mohaemoyong.server.oauth2.payload.AuthResponse;
+import shinhan.mohaemoyong.server.oauth2.payload.LoginRequest;
+import shinhan.mohaemoyong.server.oauth2.payload.SignUpRequest;
+import shinhan.mohaemoyong.server.oauth2.security.TokenProvider;
+import shinhan.mohaemoyong.server.repository.UserRepository;
+
+import java.net.URI;
+
+@RestController
+@RequestMapping("/auth")
+public class AuthController {
+
+    @Autowired
+    private AuthenticationManager authenticationManager;
+
+    @Autowired
+    private UserRepository userRepository;
+
+    @Autowired
+    private PasswordEncoder passwordEncoder;
+
+    @Autowired
+    private TokenProvider tokenProvider;
+
+    @PostMapping("/login")
+    public ResponseEntity<?> authenticateUser(@Valid @RequestBody LoginRequest loginRequest) {
+
+        Authentication authentication = authenticationManager.authenticate(
+                new UsernamePasswordAuthenticationToken(
+                        loginRequest.getEmail(),
+                        loginRequest.getPassword()
+                )
+        );
+
+        SecurityContextHolder.getContext().setAuthentication(authentication);
+
+        String token = tokenProvider.createToken(authentication);
+        return ResponseEntity.ok(new AuthResponse(token));
+    }
+
+    @PostMapping("/signup")
+    public ResponseEntity<?> registerUser(@Valid @RequestBody SignUpRequest signUpRequest) {
+        if(userRepository.existsByEmail(signUpRequest.getEmail())) {
+            throw new BadRequestException("Email address already in use.");
+        }
+
+        // Creating user's account
+        User user = new User();
+        user.setName(signUpRequest.getName());
+        user.setEmail(signUpRequest.getEmail());
+        user.setPassword(signUpRequest.getPassword());
+        user.setProvider(AuthProvider.local);
+
+        user.setPassword(passwordEncoder.encode(user.getPassword()));
+
+        User result = userRepository.save(user);
+
+        URI location = ServletUriComponentsBuilder
+                .fromCurrentContextPath().path("/user/me")
+                .buildAndExpand(result.getId()).toUri();
+
+        return ResponseEntity.created(location)
+                .body(new ApiResponse(true, "User registered successfully@"));
+    }
+
+}

--- a/server/src/main/java/shinhan/mohaemoyong/server/oauth2/payload/ApiResponse.java
+++ b/server/src/main/java/shinhan/mohaemoyong/server/oauth2/payload/ApiResponse.java
@@ -1,0 +1,19 @@
+package shinhan.mohaemoyong.server.oauth2.payload;
+
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter @Setter
+public class ApiResponse {
+    private boolean success;
+    private String message;
+
+    public ApiResponse(boolean success, String message) {
+        this.success = success;
+        this.message = message;
+    }
+
+    public boolean isSuccess() {
+        return success;
+    }
+}

--- a/server/src/main/java/shinhan/mohaemoyong/server/oauth2/payload/AuthResponse.java
+++ b/server/src/main/java/shinhan/mohaemoyong/server/oauth2/payload/AuthResponse.java
@@ -1,0 +1,14 @@
+package shinhan.mohaemoyong.server.oauth2.payload;
+
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter @Setter
+public class AuthResponse {
+    private String accessToken;
+    private String tokenType = "Bearer";
+
+    public AuthResponse(String accessToken) {
+        this.accessToken = accessToken;
+    }
+}

--- a/server/src/main/java/shinhan/mohaemoyong/server/oauth2/payload/LoginRequest.java
+++ b/server/src/main/java/shinhan/mohaemoyong/server/oauth2/payload/LoginRequest.java
@@ -1,0 +1,20 @@
+package shinhan.mohaemoyong.server.oauth2.payload;
+
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import lombok.Getter;
+import lombok.Setter;
+
+/**
+ * Created by rajeevkumarsingh on 02/08/17.
+ */
+@Getter
+@Setter
+public class LoginRequest {
+    @NotBlank
+    @Email
+    private String email;
+
+    @NotBlank
+    private String password;
+}

--- a/server/src/main/java/shinhan/mohaemoyong/server/oauth2/payload/SignUpRequest.java
+++ b/server/src/main/java/shinhan/mohaemoyong/server/oauth2/payload/SignUpRequest.java
@@ -1,0 +1,25 @@
+package shinhan.mohaemoyong.server.oauth2.payload;
+
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import lombok.Getter;
+import lombok.Setter;
+
+
+/**
+ * Created by rajeevkumarsingh on 02/08/17.
+ */
+
+@Getter @Setter
+public class SignUpRequest {
+    @NotBlank
+    private String name;
+
+    @NotBlank
+    @Email
+    private String email;
+
+    @NotBlank
+    private String password;
+
+}

--- a/server/src/main/java/shinhan/mohaemoyong/server/oauth2/security/CurrentUser.java
+++ b/server/src/main/java/shinhan/mohaemoyong/server/oauth2/security/CurrentUser.java
@@ -1,0 +1,13 @@
+package shinhan.mohaemoyong.server.oauth2.security;
+
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+
+import java.lang.annotation.*;
+
+@Target({ElementType.PARAMETER, ElementType.TYPE})
+@Retention(RetentionPolicy.RUNTIME)
+@Documented
+@AuthenticationPrincipal
+public @interface CurrentUser {
+
+}

--- a/server/src/main/java/shinhan/mohaemoyong/server/oauth2/security/CustomUserDetailsService.java
+++ b/server/src/main/java/shinhan/mohaemoyong/server/oauth2/security/CustomUserDetailsService.java
@@ -1,0 +1,44 @@
+package shinhan.mohaemoyong.server.oauth2.security;
+
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import shinhan.mohaemoyong.server.exception.ResourceNotFoundException;
+import shinhan.mohaemoyong.server.model.entity.User;
+import shinhan.mohaemoyong.server.repository.UserRepository;
+
+
+/**
+ * Created by rajeevkumarsingh on 02/08/17.
+ */
+
+@Service
+public class CustomUserDetailsService implements UserDetailsService {
+
+    @Autowired
+    private UserRepository userRepository;
+
+    @Override
+    @Transactional
+    public UserDetails loadUserByUsername(String email) throws UsernameNotFoundException {
+        User user = userRepository.findByEmail(email)
+                .orElseThrow(() ->
+                        new UsernameNotFoundException("User not found with email : " + email)
+        );
+
+        return UserPrincipal.create(user);
+    }
+
+    @Transactional
+    public UserDetails loadUserById(Long id) {
+        User user = userRepository.findById(id).orElseThrow(
+            () -> new ResourceNotFoundException("User", "id", id)
+        );
+
+        return UserPrincipal.create(user);
+    }
+}

--- a/server/src/main/java/shinhan/mohaemoyong/server/oauth2/security/RestAuthenticationEntryPoint.java
+++ b/server/src/main/java/shinhan/mohaemoyong/server/oauth2/security/RestAuthenticationEntryPoint.java
@@ -1,0 +1,25 @@
+package shinhan.mohaemoyong.server.oauth2.security;
+
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.AuthenticationEntryPoint;
+
+import java.io.IOException;
+
+public class RestAuthenticationEntryPoint implements AuthenticationEntryPoint {
+
+    private static final Logger logger = LoggerFactory.getLogger(RestAuthenticationEntryPoint.class);
+
+    @Override
+    public void commence(HttpServletRequest httpServletRequest,
+                         HttpServletResponse httpServletResponse,
+                         AuthenticationException e) throws IOException, ServletException {
+        logger.error("Responding with unauthorized error. Message - {}", e.getMessage());
+        httpServletResponse.sendError(HttpServletResponse.SC_UNAUTHORIZED,
+                e.getLocalizedMessage());
+    }
+}

--- a/server/src/main/java/shinhan/mohaemoyong/server/oauth2/security/TokenAuthenticationFilter.java
+++ b/server/src/main/java/shinhan/mohaemoyong/server/oauth2/security/TokenAuthenticationFilter.java
@@ -1,0 +1,57 @@
+package shinhan.mohaemoyong.server.oauth2.security;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.web.authentication.WebAuthenticationDetailsSource;
+import org.springframework.util.StringUtils;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+
+public class TokenAuthenticationFilter extends OncePerRequestFilter {
+
+    @Autowired
+    private TokenProvider tokenProvider;
+
+    @Autowired
+    private CustomUserDetailsService customUserDetailsService;
+
+    private static final Logger logger = LoggerFactory.getLogger(TokenAuthenticationFilter.class);
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain) throws ServletException, IOException {
+        try {
+            String jwt = getJwtFromRequest(request);
+
+            if (StringUtils.hasText(jwt) && tokenProvider.validateToken(jwt)) {
+                Long userId = tokenProvider.getUserIdFromToken(jwt);
+
+                UserDetails userDetails = customUserDetailsService.loadUserById(userId);
+                UsernamePasswordAuthenticationToken authentication = new UsernamePasswordAuthenticationToken(userDetails, null, userDetails.getAuthorities());
+                authentication.setDetails(new WebAuthenticationDetailsSource().buildDetails(request));
+
+                SecurityContextHolder.getContext().setAuthentication(authentication);
+            }
+        } catch (Exception ex) {
+            logger.error("Could not set user authentication in security context", ex);
+        }
+
+        filterChain.doFilter(request, response);
+    }
+
+    private String getJwtFromRequest(HttpServletRequest request) {
+        String bearerToken = request.getHeader("Authorization");
+        if (StringUtils.hasText(bearerToken) && bearerToken.startsWith("Bearer ")) {
+            return bearerToken.substring(7, bearerToken.length());
+        }
+        return null;
+    }
+}

--- a/server/src/main/java/shinhan/mohaemoyong/server/oauth2/security/TokenProvider.java
+++ b/server/src/main/java/shinhan/mohaemoyong/server/oauth2/security/TokenProvider.java
@@ -1,0 +1,66 @@
+package shinhan.mohaemoyong.server.oauth2.security;
+
+import io.jsonwebtoken.*;
+import io.jsonwebtoken.security.SignatureException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.security.core.Authentication;
+import org.springframework.stereotype.Service;
+import shinhan.mohaemoyong.server.oauth2.config.AppProperties;
+
+import java.util.Date;
+
+@Service
+public class TokenProvider {
+
+    private static final Logger logger = LoggerFactory.getLogger(TokenProvider.class);
+
+    private AppProperties appProperties;
+
+    public TokenProvider(AppProperties appProperties) {
+        this.appProperties = appProperties;
+    }
+
+    public String createToken(Authentication authentication) {
+        UserPrincipal userPrincipal = (UserPrincipal) authentication.getPrincipal();
+
+        Date now = new Date();
+        Date expiryDate = new Date(now.getTime() + appProperties.getAuth().getTokenExpirationMsec());
+
+        return Jwts.builder()
+                .setSubject(Long.toString(userPrincipal.getId()))
+                .setIssuedAt(new Date())
+                .setExpiration(expiryDate)
+                .signWith(SignatureAlgorithm.HS512, appProperties.getAuth().getTokenSecret())
+                .compact();
+
+    }
+
+    public Long getUserIdFromToken(String token) {
+        Claims claims = Jwts.parser()
+                .setSigningKey(appProperties.getAuth().getTokenSecret())
+                .parseClaimsJws(token)
+                .getBody();
+
+        return Long.parseLong(claims.getSubject());
+    }
+
+    public boolean validateToken(String authToken) {
+        try {
+            Jwts.parser().setSigningKey(appProperties.getAuth().getTokenSecret()).parseClaimsJws(authToken);
+            return true;
+        } catch (SignatureException ex) {
+            logger.error("Invalid JWT signature");
+        } catch (MalformedJwtException ex) {
+            logger.error("Invalid JWT token");
+        } catch (ExpiredJwtException ex) {
+            logger.error("Expired JWT token");
+        } catch (UnsupportedJwtException ex) {
+            logger.error("Unsupported JWT token");
+        } catch (IllegalArgumentException ex) {
+            logger.error("JWT claims string is empty.");
+        }
+        return false;
+    }
+
+}

--- a/server/src/main/java/shinhan/mohaemoyong/server/oauth2/security/UserPrincipal.java
+++ b/server/src/main/java/shinhan/mohaemoyong/server/oauth2/security/UserPrincipal.java
@@ -1,0 +1,102 @@
+package shinhan.mohaemoyong.server.oauth2.security;
+
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.oauth2.core.user.OAuth2User;
+import shinhan.mohaemoyong.server.model.entity.User;
+
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+
+public class UserPrincipal implements OAuth2User, UserDetails {
+    private Long id;
+    private String email;
+    private String password;
+    private Collection<? extends GrantedAuthority> authorities;
+    private Map<String, Object> attributes;
+
+    public UserPrincipal(Long id, String email, String password, Collection<? extends GrantedAuthority> authorities) {
+        this.id = id;
+        this.email = email;
+        this.password = password;
+        this.authorities = authorities;
+    }
+
+    public static UserPrincipal create(User user) {
+        List<GrantedAuthority> authorities = Collections.
+                singletonList(new SimpleGrantedAuthority("ROLE_USER"));
+
+        return new UserPrincipal(
+                user.getId(),
+                user.getEmail(),
+                user.getPassword(),
+                authorities
+        );
+    }
+
+    public static UserPrincipal create(User user, Map<String, Object> attributes) {
+        UserPrincipal userPrincipal = UserPrincipal.create(user);
+        userPrincipal.setAttributes(attributes);
+        return userPrincipal;
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public String getEmail() {
+        return email;
+    }
+
+    @Override
+    public String getPassword() {
+        return password;
+    }
+
+    @Override
+    public String getUsername() {
+        return email;
+    }
+
+    @Override
+    public boolean isAccountNonExpired() {
+        return true;
+    }
+
+    @Override
+    public boolean isAccountNonLocked() {
+        return true;
+    }
+
+    @Override
+    public boolean isCredentialsNonExpired() {
+        return true;
+    }
+
+    @Override
+    public boolean isEnabled() {
+        return true;
+    }
+
+    @Override
+    public Collection<? extends GrantedAuthority> getAuthorities() {
+        return authorities;
+    }
+
+    @Override
+    public Map<String, Object> getAttributes() {
+        return attributes;
+    }
+
+    public void setAttributes(Map<String, Object> attributes) {
+        this.attributes = attributes;
+    }
+
+    @Override
+    public String getName() {
+        return String.valueOf(id);
+    }
+}

--- a/server/src/main/java/shinhan/mohaemoyong/server/oauth2/security/oauth2/CustomOAuth2UserService.java
+++ b/server/src/main/java/shinhan/mohaemoyong/server/oauth2/security/oauth2/CustomOAuth2UserService.java
@@ -1,0 +1,84 @@
+package shinhan.mohaemoyong.server.oauth2.security.oauth2;
+
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.security.authentication.InternalAuthenticationServiceException;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.oauth2.client.userinfo.DefaultOAuth2UserService;
+import org.springframework.security.oauth2.client.userinfo.OAuth2UserRequest;
+import org.springframework.security.oauth2.core.OAuth2AuthenticationException;
+import org.springframework.security.oauth2.core.user.OAuth2User;
+import org.springframework.stereotype.Service;
+import org.springframework.util.StringUtils;
+import shinhan.mohaemoyong.server.exception.OAuth2AuthenticationProcessingException;
+import shinhan.mohaemoyong.server.model.entity.User;
+import shinhan.mohaemoyong.server.oauth2.AuthProvider;
+import shinhan.mohaemoyong.server.oauth2.security.UserPrincipal;
+import shinhan.mohaemoyong.server.oauth2.security.oauth2.user.OAuth2UserInfo;
+import shinhan.mohaemoyong.server.oauth2.security.oauth2.user.OAuth2UserInfoFactory;
+import shinhan.mohaemoyong.server.repository.UserRepository;
+
+import java.util.Optional;
+
+@Service
+public class CustomOAuth2UserService extends DefaultOAuth2UserService {
+
+    @Autowired
+    private UserRepository userRepository;
+
+    //백엔드 리다이렉션 페이지에서 토큰을 받은 후 리소스에 다시 요청해서 유저 정보를 받아옴
+    @Override
+    public OAuth2User loadUser(OAuth2UserRequest oAuth2UserRequest) throws OAuth2AuthenticationException {
+        OAuth2User oAuth2User = super.loadUser(oAuth2UserRequest);
+        try {
+            return processOAuth2User(oAuth2UserRequest, oAuth2User);
+        } catch (AuthenticationException ex) {
+            throw ex;
+        } catch (Exception ex) {
+            // Throwing an instance of AuthenticationException will trigger the OAuth2AuthenticationFailureHandler
+            throw new InternalAuthenticationServiceException(ex.getMessage(), ex.getCause());
+        }
+    }
+
+    private OAuth2User processOAuth2User(OAuth2UserRequest oAuth2UserRequest, OAuth2User oAuth2User) {
+        OAuth2UserInfo oAuth2UserInfo = OAuth2UserInfoFactory.getOAuth2UserInfo(oAuth2UserRequest, oAuth2User.getAttributes());
+
+        if(StringUtils.isEmpty(oAuth2UserInfo.getEmail())) {
+            throw new OAuth2AuthenticationProcessingException("Email not found from OAuth2 provider");
+        }
+
+        Optional<User> userOptional = userRepository.findByEmail(oAuth2UserInfo.getEmail());
+        User user;
+        if(userOptional.isPresent()) {
+            user = userOptional.get();
+            if(!user.getProvider().equals(AuthProvider.valueOf(oAuth2UserRequest.getClientRegistration().getRegistrationId()))) {
+                throw new OAuth2AuthenticationProcessingException("Looks like you're signed up with " +
+                        user.getProvider() + " account. Please use your " + user.getProvider() +
+                        " account to login.");
+            }
+            user = updateExistingUser(user, oAuth2UserInfo);
+        } else {
+            user = registerNewUser(oAuth2UserRequest, oAuth2UserInfo);
+        }
+
+        return UserPrincipal.create(user, oAuth2User.getAttributes());
+    }
+
+    private User registerNewUser(OAuth2UserRequest oAuth2UserRequest, OAuth2UserInfo oAuth2UserInfo) {
+        User user = new User();
+
+        user.setProvider(AuthProvider.valueOf(oAuth2UserRequest.getClientRegistration().getRegistrationId()));
+        user.setProviderId(oAuth2UserInfo.getId());
+        user.setName(oAuth2UserInfo.getName());
+        user.setEmail(oAuth2UserInfo.getEmail());
+        user.setImageUrl(oAuth2UserInfo.getImageUrl());
+        return userRepository.save(user);
+    }
+
+    private User updateExistingUser(User existingUser, OAuth2UserInfo oAuth2UserInfo) {
+        existingUser.setName(oAuth2UserInfo.getName());
+        existingUser.setImageUrl(oAuth2UserInfo.getImageUrl());
+        return userRepository.save(existingUser);
+    }
+
+}

--- a/server/src/main/java/shinhan/mohaemoyong/server/oauth2/security/oauth2/HttpCookieOAuth2AuthorizationRequestRepository.java
+++ b/server/src/main/java/shinhan/mohaemoyong/server/oauth2/security/oauth2/HttpCookieOAuth2AuthorizationRequestRepository.java
@@ -1,0 +1,49 @@
+package shinhan.mohaemoyong.server.oauth2.security.oauth2;
+
+import com.nimbusds.oauth2.sdk.util.StringUtils;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.security.oauth2.client.web.AuthorizationRequestRepository;
+import org.springframework.security.oauth2.core.endpoint.OAuth2AuthorizationRequest;
+import org.springframework.stereotype.Component;
+import shinhan.mohaemoyong.server.oauth2.util.CookieUtils;
+
+
+@Component
+public class HttpCookieOAuth2AuthorizationRequestRepository implements AuthorizationRequestRepository<OAuth2AuthorizationRequest> {
+    public static final String OAUTH2_AUTHORIZATION_REQUEST_COOKIE_NAME = "oauth2_auth_request";
+    public static final String REDIRECT_URI_PARAM_COOKIE_NAME = "redirect_uri";
+    private static final int cookieExpireSeconds = 180;
+
+    @Override
+    public OAuth2AuthorizationRequest loadAuthorizationRequest(HttpServletRequest request) {
+        return CookieUtils.getCookie(request, OAUTH2_AUTHORIZATION_REQUEST_COOKIE_NAME)
+                .map(cookie -> CookieUtils.deserialize(cookie, OAuth2AuthorizationRequest.class))
+                .orElse(null);
+    }
+
+    @Override
+    public void saveAuthorizationRequest(OAuth2AuthorizationRequest authorizationRequest, HttpServletRequest request, HttpServletResponse response) {
+        if (authorizationRequest == null) {
+            CookieUtils.deleteCookie(request, response, OAUTH2_AUTHORIZATION_REQUEST_COOKIE_NAME);
+            CookieUtils.deleteCookie(request, response, REDIRECT_URI_PARAM_COOKIE_NAME);
+            return;
+        }
+
+        CookieUtils.addCookie(response, OAUTH2_AUTHORIZATION_REQUEST_COOKIE_NAME, CookieUtils.serialize(authorizationRequest), cookieExpireSeconds);
+        String redirectUriAfterLogin = request.getParameter(REDIRECT_URI_PARAM_COOKIE_NAME);
+        if (StringUtils.isNotBlank(redirectUriAfterLogin)) {
+            CookieUtils.addCookie(response, REDIRECT_URI_PARAM_COOKIE_NAME, redirectUriAfterLogin, cookieExpireSeconds);
+        }
+    }
+
+    @Override
+    public OAuth2AuthorizationRequest removeAuthorizationRequest(HttpServletRequest request ,HttpServletResponse response) {
+        return this.loadAuthorizationRequest(request);
+    }
+
+    public void removeAuthorizationRequestCookies(HttpServletRequest request, HttpServletResponse response) {
+        CookieUtils.deleteCookie(request, response, OAUTH2_AUTHORIZATION_REQUEST_COOKIE_NAME);
+        CookieUtils.deleteCookie(request, response, REDIRECT_URI_PARAM_COOKIE_NAME);
+    }
+}

--- a/server/src/main/java/shinhan/mohaemoyong/server/oauth2/security/oauth2/OAuth2AuthenticationFailureHandler.java
+++ b/server/src/main/java/shinhan/mohaemoyong/server/oauth2/security/oauth2/OAuth2AuthenticationFailureHandler.java
@@ -1,0 +1,39 @@
+package shinhan.mohaemoyong.server.oauth2.security.oauth2;
+
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.authentication.SimpleUrlAuthenticationFailureHandler;
+import org.springframework.stereotype.Component;
+import org.springframework.web.util.UriComponentsBuilder;
+import shinhan.mohaemoyong.server.oauth2.util.CookieUtils;
+
+import java.io.IOException;
+
+import static shinhan.mohaemoyong.server.oauth2.security.oauth2.HttpCookieOAuth2AuthorizationRequestRepository.REDIRECT_URI_PARAM_COOKIE_NAME;
+
+
+@Component
+public class OAuth2AuthenticationFailureHandler extends SimpleUrlAuthenticationFailureHandler {
+
+    @Autowired
+    HttpCookieOAuth2AuthorizationRequestRepository httpCookieOAuth2AuthorizationRequestRepository;
+
+    @Override
+    public void onAuthenticationFailure(HttpServletRequest request, HttpServletResponse response, AuthenticationException exception) throws IOException, ServletException {
+        String targetUrl = CookieUtils.getCookie(request, REDIRECT_URI_PARAM_COOKIE_NAME)
+                .map(Cookie::getValue)
+                .orElse(("/"));
+
+        targetUrl = UriComponentsBuilder.fromUriString(targetUrl)
+                .queryParam("error", exception.getLocalizedMessage())
+                .build().toUriString();
+
+        httpCookieOAuth2AuthorizationRequestRepository.removeAuthorizationRequestCookies(request, response);
+
+        getRedirectStrategy().sendRedirect(request, response, targetUrl);
+    }
+}

--- a/server/src/main/java/shinhan/mohaemoyong/server/oauth2/security/oauth2/OAuth2AuthenticationSuccessHandler.java
+++ b/server/src/main/java/shinhan/mohaemoyong/server/oauth2/security/oauth2/OAuth2AuthenticationSuccessHandler.java
@@ -1,0 +1,93 @@
+package shinhan.mohaemoyong.server.oauth2.security.oauth2;
+
+
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.web.authentication.SimpleUrlAuthenticationSuccessHandler;
+import org.springframework.stereotype.Component;
+import org.springframework.web.util.UriComponentsBuilder;
+import shinhan.mohaemoyong.server.exception.BadRequestException;
+import shinhan.mohaemoyong.server.oauth2.config.AppProperties;
+import shinhan.mohaemoyong.server.oauth2.security.TokenProvider;
+import shinhan.mohaemoyong.server.oauth2.util.CookieUtils;
+
+import java.io.IOException;
+import java.net.URI;
+import java.util.Optional;
+
+import static shinhan.mohaemoyong.server.oauth2.security.oauth2.HttpCookieOAuth2AuthorizationRequestRepository.REDIRECT_URI_PARAM_COOKIE_NAME;
+
+
+@Component
+public class OAuth2AuthenticationSuccessHandler extends SimpleUrlAuthenticationSuccessHandler {
+
+    private TokenProvider tokenProvider;
+
+    private AppProperties appProperties;
+
+    private HttpCookieOAuth2AuthorizationRequestRepository httpCookieOAuth2AuthorizationRequestRepository;
+
+
+    @Autowired
+    OAuth2AuthenticationSuccessHandler(TokenProvider tokenProvider, AppProperties appProperties,
+                                       HttpCookieOAuth2AuthorizationRequestRepository httpCookieOAuth2AuthorizationRequestRepository) {
+        this.tokenProvider = tokenProvider;
+        this.appProperties = appProperties;
+        this.httpCookieOAuth2AuthorizationRequestRepository = httpCookieOAuth2AuthorizationRequestRepository;
+    }
+
+    @Override
+    public void onAuthenticationSuccess(HttpServletRequest request, HttpServletResponse response, Authentication authentication) throws IOException, ServletException {
+        String targetUrl = determineTargetUrl(request, response, authentication);
+
+        if (response.isCommitted()) {
+            logger.debug("Response has already been committed. Unable to redirect to " + targetUrl);
+            return;
+        }
+
+        clearAuthenticationAttributes(request, response);
+        getRedirectStrategy().sendRedirect(request, response, targetUrl);
+    }
+
+    protected String determineTargetUrl(HttpServletRequest request, HttpServletResponse response, Authentication authentication) {
+        Optional<String> redirectUri = CookieUtils.getCookie(request, REDIRECT_URI_PARAM_COOKIE_NAME)
+                .map(Cookie::getValue);
+
+        if(redirectUri.isPresent() && !isAuthorizedRedirectUri(redirectUri.get())) {
+            throw new BadRequestException("Sorry! We've got an Unauthorized Redirect URI and can't proceed with the authentication");
+        }
+
+        String targetUrl = redirectUri.orElse(getDefaultTargetUrl());
+
+        String token = tokenProvider.createToken(authentication);
+
+        return UriComponentsBuilder.fromUriString(targetUrl)
+                .queryParam("token", token)
+                .build().toUriString();
+    }
+
+    protected void clearAuthenticationAttributes(HttpServletRequest request, HttpServletResponse response) {
+        super.clearAuthenticationAttributes(request);
+        httpCookieOAuth2AuthorizationRequestRepository.removeAuthorizationRequestCookies(request, response);
+    }
+
+    private boolean isAuthorizedRedirectUri(String uri) {
+        URI clientRedirectUri = URI.create(uri);
+
+        return appProperties.getOauth2().getAuthorizedRedirectUris()
+                .stream()
+                .anyMatch(authorizedRedirectUri -> {
+                    // Only validate host and port. Let the clients use different paths if they want to
+                    URI authorizedURI = URI.create(authorizedRedirectUri);
+                    if(authorizedURI.getHost().equalsIgnoreCase(clientRedirectUri.getHost())
+                            && authorizedURI.getPort() == clientRedirectUri.getPort()) {
+                        return true;
+                    }
+                    return false;
+                });
+    }
+}

--- a/server/src/main/java/shinhan/mohaemoyong/server/oauth2/security/oauth2/user/KakaoOAuth2UserInfo.java
+++ b/server/src/main/java/shinhan/mohaemoyong/server/oauth2/security/oauth2/user/KakaoOAuth2UserInfo.java
@@ -1,0 +1,32 @@
+package shinhan.mohaemoyong.server.oauth2.security.oauth2.user;
+
+import java.util.Map;
+
+public class KakaoOAuth2UserInfo extends OAuth2UserInfo {
+
+    public KakaoOAuth2UserInfo(Map<String, Object> attributes) {
+        super(attributes);
+    }
+
+    @Override
+    public String getId() {
+        return (String) attributes.get("id");
+    }
+
+    @Override
+    public String getName() {
+        return (String) attributes.get("nickname");
+    }
+
+    @Override
+    public String getEmail() {
+        return (String) attributes.get("email");
+    }
+
+    @Override
+    public String getImageUrl() {
+        return (String) attributes.get("picture");
+    }
+
+
+}

--- a/server/src/main/java/shinhan/mohaemoyong/server/oauth2/security/oauth2/user/OAuth2UserInfo.java
+++ b/server/src/main/java/shinhan/mohaemoyong/server/oauth2/security/oauth2/user/OAuth2UserInfo.java
@@ -1,0 +1,23 @@
+package shinhan.mohaemoyong.server.oauth2.security.oauth2.user;
+
+import java.util.Map;
+
+public abstract class OAuth2UserInfo {
+    protected Map<String, Object> attributes;
+
+    public OAuth2UserInfo(Map<String, Object> attributes) {
+        this.attributes = attributes;
+    }
+
+    public Map<String, Object> getAttributes() {
+        return attributes;
+    }
+
+    public abstract String getId();
+
+    public abstract String getName();
+
+    public abstract String getEmail();
+
+    public abstract String getImageUrl();
+}

--- a/server/src/main/java/shinhan/mohaemoyong/server/oauth2/security/oauth2/user/OAuth2UserInfoFactory.java
+++ b/server/src/main/java/shinhan/mohaemoyong/server/oauth2/security/oauth2/user/OAuth2UserInfoFactory.java
@@ -1,0 +1,41 @@
+package shinhan.mohaemoyong.server.oauth2.security.oauth2.user;
+
+
+import org.springframework.security.oauth2.client.userinfo.OAuth2UserRequest;
+import shinhan.mohaemoyong.server.exception.OAuth2AuthenticationProcessingException;
+import shinhan.mohaemoyong.server.oauth2.AuthProvider;
+
+import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+public class OAuth2UserInfoFactory {
+
+    public static OAuth2UserInfo getOAuth2UserInfo(OAuth2UserRequest oAuth2UserRequest, Map<String, Object> attributes) {
+        String registrationId = oAuth2UserRequest.getClientRegistration().getRegistrationId();
+
+        if(registrationId.equalsIgnoreCase(AuthProvider.kakao.toString())) {
+            return makeKakaoUserInfo(attributes);
+        }
+        else {
+            throw new OAuth2AuthenticationProcessingException("Sorry! Login with " + registrationId + " is not supported yet.");
+        }
+    }
+
+
+    public static OAuth2UserInfo makeKakaoUserInfo(Map<String, Object> attributes){
+        Map<String, Object> kakaoUserInfo = new HashMap<>();
+        kakaoUserInfo.put("id", String.valueOf(attributes.get("id")));
+        LinkedHashMap<String, Object> temporaryProperties = (LinkedHashMap<String, Object>) attributes.get("properties");
+        kakaoUserInfo.put("nickname", temporaryProperties.get("nickname"));
+        kakaoUserInfo.put("picture", temporaryProperties.get("profile_image"));
+        LinkedHashMap<String, Object> temporaryProperties2 = (LinkedHashMap<String, Object>) attributes.get("kakao_account");
+        kakaoUserInfo.put("email", temporaryProperties2.get("email"));
+
+        return new KakaoOAuth2UserInfo(kakaoUserInfo);
+    }
+
+
+
+
+}

--- a/server/src/main/java/shinhan/mohaemoyong/server/oauth2/util/CookieUtils.java
+++ b/server/src/main/java/shinhan/mohaemoyong/server/oauth2/util/CookieUtils.java
@@ -1,0 +1,60 @@
+package shinhan.mohaemoyong.server.oauth2.util;
+
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.util.SerializationUtils;
+
+import java.util.Base64;
+import java.util.Optional;
+
+public class CookieUtils {
+
+    public static Optional<Cookie> getCookie(HttpServletRequest request, String name) {
+        Cookie[] cookies = request.getCookies();
+
+        if (cookies != null && cookies.length > 0) {
+            for (Cookie cookie : cookies) {
+                if (cookie.getName().equals(name)) {
+                    return Optional.of(cookie);
+                }
+            }
+        }
+
+        return Optional.empty();
+    }
+
+    public static void addCookie(HttpServletResponse response, String name, String value, int maxAge) {
+        Cookie cookie = new Cookie(name, value);
+        cookie.setPath("/");
+        cookie.setHttpOnly(true);
+        cookie.setMaxAge(maxAge);
+        response.addCookie(cookie);
+    }
+
+    public static void deleteCookie(HttpServletRequest request, HttpServletResponse response, String name) {
+        Cookie[] cookies = request.getCookies();
+        if (cookies != null && cookies.length > 0) {
+            for (Cookie cookie: cookies) {
+                if (cookie.getName().equals(name)) {
+                    cookie.setValue("");
+                    cookie.setPath("/");
+                    cookie.setMaxAge(0);
+                    response.addCookie(cookie);
+                }
+            }
+        }
+    }
+
+    public static String serialize(Object object) {
+        return Base64.getUrlEncoder()
+                .encodeToString(SerializationUtils.serialize(object));
+    }
+
+    public static <T> T deserialize(Cookie cookie, Class<T> cls) {
+        return cls.cast(SerializationUtils.deserialize(
+                        Base64.getUrlDecoder().decode(cookie.getValue())));
+    }
+
+
+}

--- a/server/src/main/java/shinhan/mohaemoyong/server/repository/UserRepository.java
+++ b/server/src/main/java/shinhan/mohaemoyong/server/repository/UserRepository.java
@@ -1,0 +1,17 @@
+package shinhan.mohaemoyong.server.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+import shinhan.mohaemoyong.server.model.entity.User;
+
+import java.util.Optional;
+
+
+@Repository
+public interface UserRepository extends JpaRepository<User, Long> {
+
+    Optional<User> findByEmail(String email);
+
+    Boolean existsByEmail(String email);
+
+}


### PR DESCRIPTION
## 📌관련 이슈
- closed: #3 
## 💥작업 내용
<!-- 이슈에 표기한 작업/수정/추가한 내용등을 적어주세요. -->
- 작업 내용 1 : 디렉토리 구조 설정
- 작업 내용 2 : 카카오 소셜 로그인 구현, API테스트용 (보안 리팩토링 필요)
- 작업 내용 3 : 테스트용 로그인된 사용자 정보 응답 API 구현 (dto 리팩토링 필요)
## ✨참고 사항
- ## 테스트 로그인 흐름 :

<img width="2042" height="758" alt="Image" src="https://github.com/user-attachments/assets/77926c7d-f34b-44fc-b38e-0f47589b423e" />

1. 로그인 요청 url 입력시 카카오 소셜로그인 에게 위임
<br>
<img width="1834" height="362" alt="Image" src="https://github.com/user-attachments/assets/531bd290-fb35-480f-8410-e3d884996f0d" />

2. 소셜 로그인 성공 시 밑줄친 토큰이 주소의 쿼리스트링에 담아져서 프론트에 제공됨, 이걸 프런트에서는 쿠키저장소에 저장
<br>
<img width="859" height="693" alt="Image" src="https://github.com/user-attachments/assets/c9351ade-cea6-4eff-b3c6-0475592177b6" />

3. 백엔드에서 POSTMAN으로 API 테스트하는 예시 
    - (프런트에서) 로그인이 필요한 페이지엔 **요청 헤더에 Authorization에 Bearer {인가코드}**를 넣어서 요청해야함
        - (해당 이미지는 로그인된 유저의 정보를 조회하는 API 예시)
