### PR TITLE
[Server] fix : 해당 일정 상세 조회 API #13

### DIFF
--- a/server/src/main/java/shinhan/mohaemoyong/server/controller/DetailPlanController.java
+++ b/server/src/main/java/shinhan/mohaemoyong/server/controller/DetailPlanController.java
@@ -4,21 +4,24 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 import shinhan.mohaemoyong.server.dto.DetailPlanResponse;
+import shinhan.mohaemoyong.server.oauth2.security.CurrentUser;
+import shinhan.mohaemoyong.server.oauth2.security.UserPrincipal;
 import shinhan.mohaemoyong.server.service.DetailPlanService;
 
 @RestController
 @RequiredArgsConstructor
-@RequestMapping("/api/users/{userId}/plans")
+@RequestMapping("/api/v1/plans")
 public class DetailPlanController {
 
     private final DetailPlanService detailPlanService;
 
-    // GET /api/users/{userId}/plans/{planId}
+    // GET /api/v1/plans/{planId}
     @GetMapping("/{planId}")
     public ResponseEntity<DetailPlanResponse> getDetail(
-            @PathVariable Long userId,
+            @CurrentUser UserPrincipal userPrincipal,
             @PathVariable Long planId
     ) {
-        return ResponseEntity.ok(detailPlanService.getDetail(userId, planId));
+        Long loginUserId = userPrincipal.getId();
+        return ResponseEntity.ok(detailPlanService.getDetail(loginUserId, planId));
     }
 }


### PR DESCRIPTION
## 📌관련 이슈

- closed

## 💥작업 내용

- 컨트롤러에서 `@PathVariable Long userId` 제거, `@CurrentUser UserPrincipal userPrincipal` 주입으로 전환
- `GET /api/v1/plans/{planId}` (권장, 신규 경로)로 통합
- 서비스 시그니처: `getDetail(Long userId, Long planId)` → `getDetail(Long loginUserId, Long planId)`

## ✨참고 사항

### 테스트 방법: 상세 조회

**요청**

```
GET http://localhost:8080/api/v1/plans/{planId}

```