### PR TITLE
feature : 특정 친구의 이번 주 일정 조회 API 추가 (PRIVATE 일정 제외)

### DIFF
--- a/server/src/main/java/shinhan/mohaemoyong/server/controller/HomeController.java
+++ b/server/src/main/java/shinhan/mohaemoyong/server/controller/HomeController.java
@@ -17,8 +17,15 @@ public class HomeController {
     private final HomeService homeService;
 
     // GET /api/v1/home/plans/week?userId=1
+    // ✅ 내 일정 조회 (기존)
     @GetMapping("/plans/week/myPlans")
     public List<HomeWeekResponse> getThisWeekPlans(@CurrentUser UserPrincipal userPrincipal) {
         return homeService.getThisWeekPlans(userPrincipal.getId());
+    }
+
+    // ✅ 친구 일정 조회
+    @GetMapping("/plans/week/friend/{friendId}")
+    public List<HomeWeekResponse> getFriendThisWeekPlans(@PathVariable Long friendId) {
+        return homeService.getThisWeekPlans(friendId);
     }
 }

--- a/server/src/main/java/shinhan/mohaemoyong/server/repository/PlanRepository.java
+++ b/server/src/main/java/shinhan/mohaemoyong/server/repository/PlanRepository.java
@@ -23,6 +23,7 @@ public interface PlanRepository extends JpaRepository<Plans, Long> {
           AND p.deletedAt IS NULL
           AND p.startTime < :endOfWeek
           AND p.endTime   >= :startOfWeek
+          AND p.privacyLevel <> 'PRIVATE'
         ORDER BY p.startTime ASC
 """)
     List<HomeWeekResponse> findWeeklyPlans(


### PR DESCRIPTION
## 📌관련 이슈
- closed: #19 
## 💥작업 내용
- 특정 친구의 이번 주 일정 조회 API 추가
- PRIVATE 일정은 제외되도록 쿼리 조건 반영
## ✨참고 사항
- 조회 시 친구의 일정 privacy_level 이 'friends_only' 또는 'public' 인 경우만 응답에 포함



