### PR TITLE
[Server] feature : 해당 일정 수정/삭제 API

### DIFF
--- a/server/src/main/java/shinhan/mohaemoyong/server/controller/DetailPlanController.java
+++ b/server/src/main/java/shinhan/mohaemoyong/server/controller/DetailPlanController.java
@@ -4,6 +4,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 import shinhan.mohaemoyong.server.dto.DetailPlanResponse;
+import shinhan.mohaemoyong.server.dto.DetailPlanUpdateRequest;
 import shinhan.mohaemoyong.server.oauth2.security.CurrentUser;
 import shinhan.mohaemoyong.server.oauth2.security.UserPrincipal;
 import shinhan.mohaemoyong.server.service.DetailPlanService;
@@ -23,5 +24,27 @@ public class DetailPlanController {
     ) {
         Long loginUserId = userPrincipal.getId();
         return ResponseEntity.ok(detailPlanService.getDetail(loginUserId, planId));
+    }
+
+    // PATCH /api/v1/plans/{planId}
+    @PatchMapping("/{planId}")
+    public ResponseEntity<DetailPlanResponse> updateDetail(
+            @CurrentUser UserPrincipal userPrincipal,
+            @PathVariable Long planId,
+            @RequestBody DetailPlanUpdateRequest request
+    ) {
+        Long loginUserId = userPrincipal.getId();
+        return ResponseEntity.ok(detailPlanService.update(loginUserId, planId, request));
+    }
+
+    // DELETE /api/v1/plans/{planId}
+    @DeleteMapping("/{planId}")
+    public ResponseEntity<Void> delete(
+            @CurrentUser UserPrincipal userPrincipal,
+            @PathVariable Long planId
+    ) {
+        Long loginUserId = userPrincipal.getId();
+        detailPlanService.delete(loginUserId, planId);
+        return ResponseEntity.noContent().build();
     }
 }

--- a/server/src/main/java/shinhan/mohaemoyong/server/domain/Plans.java
+++ b/server/src/main/java/shinhan/mohaemoyong/server/domain/Plans.java
@@ -6,6 +6,7 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.hibernate.annotations.CreationTimestamp;
 import org.hibernate.annotations.UpdateTimestamp;
+import shinhan.mohaemoyong.server.dto.DetailPlanUpdateRequest;
 
 import java.time.Instant;
 import java.time.LocalDateTime;
@@ -108,5 +109,43 @@ public class Plans {
     void addComment(Comments c) {
         comments.add(c);
         if (c.getPlan() != this) c.setPlanInternal(this);
+    }
+
+
+    public void applyUpdate(DetailPlanUpdateRequest req, LocalDateTime now) {
+        if (req.title()        != null) this.title = req.title();
+        if (req.content()      != null) this.content = req.content();
+        if (req.imageUrl()     != null) this.imageUrl = req.imageUrl();
+        if (req.place()        != null) this.place = req.place();
+        if (req.startTime()    != null) this.startTime = req.startTime();
+        if (req.endTime()      != null) this.endTime = req.endTime();
+        if (req.isCompleted()  != null) this.isCompleted = req.isCompleted();
+        if (req.hasSavingsGoal()!= null) this.hasSavingsGoal = req.hasSavingsGoal();
+
+        // savingsAmount 규칙
+        if (req.hasSavingsGoal() != null) {
+            if (req.hasSavingsGoal()) {
+                if (req.savingsAmount() != null) this.savingsAmount = req.savingsAmount();
+            } else {
+                this.savingsAmount = null;
+            }
+        } else if (req.savingsAmount() != null && this.hasSavingsGoal) {
+            this.savingsAmount = req.savingsAmount();
+        }
+
+        if (req.privacyLevel() != null) this.privacyLevel = req.privacyLevel();
+
+        this.updatedAt = now;
+    }
+
+    public boolean isDeleted() {
+        return this.deletedAt != null;
+    }
+
+    public void softDelete(LocalDateTime now) {
+        if (this.deletedAt == null) {
+            this.deletedAt = now;
+            this.updatedAt = now;
+        }
     }
 }

--- a/server/src/main/java/shinhan/mohaemoyong/server/dto/DetailPlanUpdateRequest.java
+++ b/server/src/main/java/shinhan/mohaemoyong/server/dto/DetailPlanUpdateRequest.java
@@ -1,0 +1,19 @@
+package shinhan.mohaemoyong.server.dto;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+
+import java.time.LocalDateTime;
+
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public record DetailPlanUpdateRequest(
+        String title,
+        String content,
+        String imageUrl,
+        String place,
+        LocalDateTime startTime,
+        LocalDateTime endTime,
+        Boolean isCompleted,
+        Boolean hasSavingsGoal,
+        Integer savingsAmount,
+        String privacyLevel   // "PRIVATE" | "PUBLIC"
+) {}

--- a/server/src/main/java/shinhan/mohaemoyong/server/service/DetailPlanService.java
+++ b/server/src/main/java/shinhan/mohaemoyong/server/service/DetailPlanService.java
@@ -5,14 +5,19 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import shinhan.mohaemoyong.server.domain.Plans;
 import shinhan.mohaemoyong.server.dto.DetailPlanResponse;
+import shinhan.mohaemoyong.server.dto.DetailPlanUpdateRequest;
 import shinhan.mohaemoyong.server.exception.ResourceNotFoundException;
 import shinhan.mohaemoyong.server.repository.PlanRepository;
+
+import java.time.LocalDateTime;
+import java.util.Set;
 
 @Service
 @RequiredArgsConstructor
 public class DetailPlanService {
 
     private final PlanRepository planRepository;
+    private static final Set<String> PRIVACY_ALLOWED = Set.of("PUBLIC", "PRIVATE");
 
     @Transactional(readOnly = true)
     public DetailPlanResponse getDetail(Long userId, Long planId) {
@@ -22,7 +27,43 @@ public class DetailPlanService {
                         new ResourceNotFoundException("Plans", "planId/userId", planId + "/" + userId)
                 );
 
+        return toResponse(p);
+    }
 
+    @Transactional
+    public DetailPlanResponse update(Long loginUserId, Long planId, DetailPlanUpdateRequest req) {
+        Plans p = planRepository.findDetailByOwner(loginUserId, planId)
+                .orElseThrow(() -> new ResourceNotFoundException("Plans", "planId/userId", planId + "/" + loginUserId));
+
+        if (p.isDeleted()) throw new ResourceNotFoundException("Plans", "planId", planId);
+        if (req.startTime() != null && req.endTime() != null && req.startTime().isAfter(req.endTime()))
+            throw new IllegalArgumentException("startTime must be before endTime");
+
+        if (req.privacyLevel() != null) {
+            String normalized = req.privacyLevel().trim().toUpperCase();
+            if (!PRIVACY_ALLOWED.contains(normalized)) {
+                throw new IllegalArgumentException("privacyLevel must be one of " + PRIVACY_ALLOWED);
+            }
+
+            req = new DetailPlanUpdateRequest(
+                    req.title(), req.content(), req.imageUrl(), req.place(),
+                    req.startTime(), req.endTime(), req.isCompleted(),
+                    req.hasSavingsGoal(), req.savingsAmount(), normalized
+            );
+        }
+
+        p.applyUpdate(req, LocalDateTime.now());
+        return toResponse(p);
+    }
+
+    @Transactional
+    public void delete(Long loginUserId, Long planId) {
+        Plans p = planRepository.findDetailByOwner(loginUserId, planId)
+                .orElseThrow(() -> new ResourceNotFoundException("Plans", "planId/userId", planId + "/" + loginUserId));
+        p.softDelete(LocalDateTime.now());
+    }
+
+    private DetailPlanResponse toResponse(Plans p) {
         return new DetailPlanResponse(
                 p.getPlanId(),
                 p.getUser().getId(),
@@ -36,8 +77,9 @@ public class DetailPlanService {
                 p.isCompleted(),
                 p.isHasSavingsGoal(),
                 p.getSavingsAmount(),
-                p.getPrivacyLevel(),
+                p.getPrivacyLevel(), // "PUBLIC" / "PRIVATE"
                 p.getCommentCount() == null ? 0 : p.getCommentCount()
         );
     }
+
 }


### PR DESCRIPTION
## 📌관련 이슈
- closed: #17

## 💥작업 내용
- 일정 상세 수정 API 구현 (`PATCH /api/v1/plans/{planId}`)
    - DTO(`DetailPlanUpdateRequest`) 기반으로 빌더패턴 업데이트 적용
    - `privacyLevel` 유효성 검사 및 start/endTime 검증 추가
- 일정 삭제 API 구현 (`DELETE /api/v1/plans/{planId}`)
    - Soft Delete 방식 적용 (`deleted_at` 컬럼 업데이트)
    - 성공 시 `204 No Content` 응답 반환

## ✨참고 사항
- 수정/삭제 모두 로그인 사용자 토큰 기반 권한 체크
- 삭제된 일정은 조회 불가하도록 처리됨