### PR TITLE
feature : 친구 새로운 일정 등록 여부 확인 및 확인 처리 API 추가

### DIFF
--- a/server/src/main/java/shinhan/mohaemoyong/server/controller/FriendPlanController.java
+++ b/server/src/main/java/shinhan/mohaemoyong/server/controller/FriendPlanController.java
@@ -1,0 +1,29 @@
+package shinhan.mohaemoyong.server.controller;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.*;
+import shinhan.mohaemoyong.server.oauth2.security.CurrentUser;
+import shinhan.mohaemoyong.server.oauth2.security.UserPrincipal;
+import shinhan.mohaemoyong.server.service.FriendPlanService;
+
+@RestController
+@RequestMapping("/api/v1/friends")
+@RequiredArgsConstructor
+public class FriendPlanController {
+
+    private final FriendPlanService friendPlanService;
+
+    /** 친구가 이번주 새 일정 등록했는지 확인 (빨간테두리 여부) */
+    @GetMapping("/{friendId}/plans/new")
+    public boolean hasNewPlanThisWeek(@CurrentUser UserPrincipal userPrincipal,
+                                      @PathVariable Long friendId) {
+        return friendPlanService.hasNewPlanThisWeek(userPrincipal.getId(), friendId);
+    }
+
+    /** 친구 일정 확인 완료 (빨간테두리 제거) */
+    @PostMapping("/{friendId}/plans/seen")
+    public void markPlansAsSeen(@CurrentUser UserPrincipal userPrincipal,
+                                @PathVariable Long friendId) {
+        friendPlanService.markPlansAsSeen(userPrincipal.getId(), friendId);
+    }
+}

--- a/server/src/main/java/shinhan/mohaemoyong/server/domain/FriendLastSeen.java
+++ b/server/src/main/java/shinhan/mohaemoyong/server/domain/FriendLastSeen.java
@@ -1,0 +1,40 @@
+package shinhan.mohaemoyong.server.domain;
+
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "friend_last_seen")
+@Getter
+@NoArgsConstructor
+public class FriendLastSeen {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    /** 내가 누구인지 */
+    @Column(nullable = false)
+    private Long userId;
+
+    /** 어떤 친구를 확인했는지 */
+    @Column(nullable = false)
+    private Long friendId;
+
+    /** 마지막 확인한 시간 */
+    @Column(nullable = false)
+    private LocalDateTime lastSeenAt;
+
+    public FriendLastSeen(Long userId, Long friendId, LocalDateTime lastSeenAt) {
+        this.userId = userId;
+        this.friendId = friendId;
+        this.lastSeenAt = lastSeenAt;
+    }
+
+    public void updateLastSeen(LocalDateTime time) {
+        this.lastSeenAt = time;
+    }
+}

--- a/server/src/main/java/shinhan/mohaemoyong/server/repository/FriendLastSeenRepository.java
+++ b/server/src/main/java/shinhan/mohaemoyong/server/repository/FriendLastSeenRepository.java
@@ -1,0 +1,12 @@
+package shinhan.mohaemoyong.server.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import shinhan.mohaemoyong.server.domain.FriendLastSeen;
+
+import java.util.Optional;
+
+public interface FriendLastSeenRepository extends JpaRepository<FriendLastSeen, Long> {
+
+    Optional<FriendLastSeen> findByUserIdAndFriendId(Long userId, Long friendId);
+
+}

--- a/server/src/main/java/shinhan/mohaemoyong/server/repository/PlanRepository.java
+++ b/server/src/main/java/shinhan/mohaemoyong/server/repository/PlanRepository.java
@@ -1,11 +1,13 @@
 package shinhan.mohaemoyong.server.repository;
 
+import org.springframework.data.domain.Page;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import shinhan.mohaemoyong.server.domain.Plans;
 import shinhan.mohaemoyong.server.dto.HomeWeekResponse;
 
+import java.awt.print.Pageable;
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
@@ -43,4 +45,20 @@ public interface PlanRepository extends JpaRepository<Plans, Long> {
     """)
     Optional<Plans> findDetailByOwner(@Param("userId") Long userId,
                                       @Param("planId") Long planId);
+
+    @Query("""
+        SELECT p FROM Plans p
+        WHERE p.user.id = :friendId
+          AND p.deletedAt IS NULL
+          AND p.privacyLevel = 'PUBLIC'
+          AND p.startTime < :endOfWeek
+          AND p.endTime   >= :startOfWeek
+        ORDER BY p.createdAt DESC
+""")
+    List<Plans> findRecentPublicPlansThisWeek(
+            @Param("friendId") Long friendId,
+            @Param("startOfWeek") LocalDateTime startOfWeek,
+            @Param("endOfWeek") LocalDateTime endOfWeek
+    );
+
 }

--- a/server/src/main/java/shinhan/mohaemoyong/server/service/FriendPlanService.java
+++ b/server/src/main/java/shinhan/mohaemoyong/server/service/FriendPlanService.java
@@ -1,0 +1,56 @@
+package shinhan.mohaemoyong.server.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import shinhan.mohaemoyong.server.domain.FriendLastSeen;
+import shinhan.mohaemoyong.server.domain.Plans;
+import shinhan.mohaemoyong.server.repository.FriendLastSeenRepository;
+import shinhan.mohaemoyong.server.repository.PlanRepository;
+
+import java.time.*;
+import java.time.temporal.TemporalAdjusters;
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class FriendPlanService {
+
+    private final PlanRepository planRepository;
+    private final FriendLastSeenRepository lastSeenRepository;
+
+    /** 이번주 새 일정이 있는지 확인 (빨간테두리용) */
+    public boolean hasNewPlanThisWeek(Long userId, Long friendId) {
+        ZoneId zone = ZoneId.of("Asia/Seoul");
+        LocalDate today = LocalDate.now(zone);
+
+        LocalDate monday = today.with(TemporalAdjusters.previousOrSame(DayOfWeek.MONDAY));
+        LocalDate sunday = today.with(TemporalAdjusters.nextOrSame(DayOfWeek.SUNDAY));
+
+        LocalDateTime startOfWeek = monday.atStartOfDay();
+        LocalDateTime endOfWeek   = sunday.atTime(LocalTime.MAX);
+
+        // 이번주 일정 중 가장 최신 생성된 일정들
+        List<Plans> recentPlans = planRepository.findRecentPublicPlansThisWeek(friendId, startOfWeek, endOfWeek);
+
+        if (recentPlans.isEmpty()) return false;
+
+        // 마지막 본 시간
+        FriendLastSeen lastSeen = lastSeenRepository
+                .findByUserIdAndFriendId(userId, friendId)
+                .orElse(new FriendLastSeen(userId, friendId, LocalDateTime.MIN));
+
+        // 하나라도 lastSeen 이후에 생성됐다면 → 새로운 일정 있음
+        return recentPlans.stream()
+                .anyMatch(p -> p.getCreatedAt().isAfter(lastSeen.getLastSeenAt()));
+    }
+
+    /** 친구 일정 확인 처리 → 빨간테두리 제거 */
+    public void markPlansAsSeen(Long userId, Long friendId) {
+        FriendLastSeen lastSeen = lastSeenRepository
+                .findByUserIdAndFriendId(userId, friendId)
+                .orElse(new FriendLastSeen(userId, friendId, LocalDateTime.now()));
+
+        lastSeen.updateLastSeen(LocalDateTime.now());
+        lastSeenRepository.save(lastSeen);
+    }
+}


### PR DESCRIPTION
## 📌관련 이슈
- closed: #22 
## 💥작업 내용
- 친구가 이번 주 새 일정을 등록했는지 확인하는 API 추가 (`GET /api/v1/friends/{friendId}/plans/new`)
- 새 일정을 확인했음을 기록하는 API 추가 (`POST /api/v1/friends/{friendId}/plans/seen`)
- FriendLastSeen 엔티티/로직 추가
## ✨참고 사항
- 새 일정이 존재하고 아직 확인하지 않았을 경우 true 반환
- 확인 처리 후 다시 조회하면 false 반환



