### PR TITLE
feature : 친구 일정 새로 등록 여부 및 확인 처리 API 추가

### DIFF
--- a/server/src/main/java/shinhan/mohaemoyong/server/controller/FriendPlanController.java
+++ b/server/src/main/java/shinhan/mohaemoyong/server/controller/FriendPlanController.java
@@ -2,9 +2,12 @@ package shinhan.mohaemoyong.server.controller;
 
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.*;
+import shinhan.mohaemoyong.server.dto.FriendWeeklyPlanDto;
 import shinhan.mohaemoyong.server.oauth2.security.CurrentUser;
 import shinhan.mohaemoyong.server.oauth2.security.UserPrincipal;
 import shinhan.mohaemoyong.server.service.FriendPlanService;
+
+import java.util.List;
 
 @RestController
 @RequestMapping("/api/v1/friends")
@@ -26,4 +29,12 @@ public class FriendPlanController {
                                 @PathVariable Long friendId) {
         friendPlanService.markPlansAsSeen(userPrincipal.getId(), friendId);
     }
+
+    @GetMapping("/{friendId}/plans/week")
+    public List<FriendWeeklyPlanDto> getFriendWeeklyPlans(
+            @CurrentUser UserPrincipal userPrincipal,
+            @PathVariable Long friendId) {
+        return friendPlanService.getFriendWeeklyPlansWithNewFlag(userPrincipal.getId(), friendId);
+    }
+
 }

--- a/server/src/main/java/shinhan/mohaemoyong/server/dto/FriendWeeklyPlanDto.java
+++ b/server/src/main/java/shinhan/mohaemoyong/server/dto/FriendWeeklyPlanDto.java
@@ -1,0 +1,17 @@
+package shinhan.mohaemoyong.server.dto;
+
+import lombok.Builder;
+import lombok.Value;
+
+import java.time.LocalDateTime;
+
+@Value
+@Builder
+public class FriendWeeklyPlanDto {
+    Long planId;
+    String title;
+    String place;
+    LocalDateTime startTime;
+    LocalDateTime endTime;
+    boolean isNew;   // lastSeenAt 이후 생성되었는지
+}


### PR DESCRIPTION
## 📌관련 이슈
- closed: #28 
## 💥작업 내용
- 친구가 이번주 새 일정 등록했는지 확인 API 추가 (GET /api/v1/friends/{friendId}/plans/new)
- 친구 주간 일정 조회 시 isNew 플래그 반영 (GET /api/v1/friends/{friendId}/plans/week)
- 친구 일정 확인 완료 처리 API 추가 (POST /api/v1/friends/{friendId}/plans/seen)
## ✨참고 사항
- 조회 시 isNew=true → 일정에 빨간 테두리 표시, 확인 완료 시 테두리 제거됨


