### PR TITLE
feature : 친구요청 기능 추가

### DIFF
--- a/server/src/main/java/shinhan/mohaemoyong/server/controller/FriendController.java
+++ b/server/src/main/java/shinhan/mohaemoyong/server/controller/FriendController.java
@@ -1,13 +1,17 @@
 package shinhan.mohaemoyong.server.controller;
 
 import lombok.RequiredArgsConstructor;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+import shinhan.mohaemoyong.server.domain.FriendRequest;
+import shinhan.mohaemoyong.server.dto.FriendRequestDto;
+import shinhan.mohaemoyong.server.dto.FriendRequestResponse;
 import shinhan.mohaemoyong.server.dto.FriendResponse;
 import shinhan.mohaemoyong.server.oauth2.security.CurrentUser;
 import shinhan.mohaemoyong.server.oauth2.security.UserPrincipal;
 import shinhan.mohaemoyong.server.service.FriendService;
+import shinhan.mohaemoyong.server.service.FriendRequestService;
 
 import java.util.List;
 
@@ -16,11 +20,63 @@ import java.util.List;
 @RequiredArgsConstructor
 public class FriendController {
 
-    private final FriendService friendService;
+    private final FriendService friendService;             // 친구 목록 관리
+    private final FriendRequestService friendRequestService; // 친구 요청 관리
 
-    // GET /api/v1/friends
+    /** 내 친구 목록 조회 */
     @GetMapping
     public List<FriendResponse> getFriends(@CurrentUser UserPrincipal userPrincipal) {
-        return friendService.getAllFriends();
+        return friendService.getAllFriends(userPrincipal);
+    }
+
+    /** 친구 요청 보내기 */
+    @PostMapping("/requests")
+    public ResponseEntity<FriendRequestResponse> sendFriendRequest(
+            @CurrentUser UserPrincipal userPrincipal,
+            @RequestBody FriendRequestDto dto) {
+
+        FriendRequest request = friendRequestService.sendRequest(userPrincipal, dto);
+        return new ResponseEntity<>(FriendRequestResponse.from(request), HttpStatus.CREATED);
+    }
+
+    /** 받은 친구 요청 목록 조회 */
+    @GetMapping("/requests/inbox")
+    public ResponseEntity<List<FriendRequestResponse>> getInbox(@CurrentUser UserPrincipal userPrincipal) {
+        return ResponseEntity.ok(friendRequestService.getReceivedRequests(userPrincipal));
+    }
+
+    /** 친구 요청 수락 */
+    @PostMapping("/requests/{requestId}/accept")
+    public ResponseEntity<FriendResponse> acceptRequest(
+            @PathVariable Long requestId,
+            @CurrentUser UserPrincipal userPrincipal
+    ) {
+        return ResponseEntity.ok(friendRequestService.acceptRequest(userPrincipal.getId(), requestId));
+    }
+
+    /** 친구 요청 거절 */
+    @PostMapping("/requests/{requestId}/decline")
+    public ResponseEntity<String> declineRequest(@PathVariable Long requestId,
+                                                 @CurrentUser UserPrincipal userPrincipal) {
+        friendRequestService.declineRequest(requestId, userPrincipal.getId());
+        return ResponseEntity.ok("친구 요청이 거절되었습니다.");
+    }
+
+    /** 보낸 요청 취소 */
+    @PostMapping("/requests/{requestId}/cancel")
+    public ResponseEntity<Void> cancelRequest(
+            @PathVariable Long requestId,
+            @CurrentUser UserPrincipal userPrincipal) {
+        friendRequestService.cancelRequest(requestId, userPrincipal.getId());
+        return ResponseEntity.ok().build(); // 200 OK만 응답
+    }
+
+    // 친구 삭제
+    @DeleteMapping("/{friendId}")
+    public ResponseEntity<String> deleteFriend(
+            @CurrentUser UserPrincipal userPrincipal,
+            @PathVariable Long friendId) {
+        friendService.deleteFriend(userPrincipal.getId(), friendId);
+        return ResponseEntity.ok("친구가 삭제되었습니다.");
     }
 }

--- a/server/src/main/java/shinhan/mohaemoyong/server/domain/FriendRequest.java
+++ b/server/src/main/java/shinhan/mohaemoyong/server/domain/FriendRequest.java
@@ -1,0 +1,46 @@
+package shinhan.mohaemoyong.server.domain;
+
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.Setter;
+import org.hibernate.annotations.CreationTimestamp;
+
+import java.time.Instant;
+
+@Entity
+@Getter @Setter
+@Table(name = "friend_requests")
+public class FriendRequest {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long requestId;
+
+    /** 요청 보낸 사람 */
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "requester_id", nullable = false)
+    private User requester;
+
+    /** 요청 받은 사람 */
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "receiver_id", nullable = false)
+    private User receiver;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false, length = 20)
+    private Status status = Status.PENDING;
+
+    private String message;
+
+    @Column(nullable = false)
+    private Boolean isActive = true;
+
+    @CreationTimestamp
+    private Instant createdAt;
+
+    private Instant respondedAt;
+
+    public enum Status {
+        PENDING, ACCEPTED, DECLINED, CANCELED
+    }
+}

--- a/server/src/main/java/shinhan/mohaemoyong/server/domain/Friendship.java
+++ b/server/src/main/java/shinhan/mohaemoyong/server/domain/Friendship.java
@@ -1,0 +1,32 @@
+package shinhan.mohaemoyong.server.domain;
+
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.Setter;
+import org.hibernate.annotations.CreationTimestamp;
+
+import java.time.Instant;
+
+@Entity
+@Getter @Setter
+@Table(
+        name = "friendships",
+        uniqueConstraints = @UniqueConstraint(columnNames = {"user_id", "friend_id"})
+)
+public class Friendship {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long friendshipId;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "friend_id", nullable = false)
+    private User friend;
+
+    @CreationTimestamp
+    private Instant createdAt;
+}

--- a/server/src/main/java/shinhan/mohaemoyong/server/domain/User.java
+++ b/server/src/main/java/shinhan/mohaemoyong/server/domain/User.java
@@ -88,6 +88,16 @@ public class User { // DB의 테이블명은 users, 백엔드 엔티티명은 us
     @OneToMany(mappedBy = "user", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<Accounts> accounts = new ArrayList<>();
 
+    @OneToMany(mappedBy = "requester", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<FriendRequest> sentRequests = new ArrayList<>();
+
+    @OneToMany(mappedBy = "receiver", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<FriendRequest> receivedRequests = new ArrayList<>();
+
+    @OneToMany(mappedBy = "user", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<Friendship> friendships = new ArrayList<>();
+
+
     /* ===========================
        연관관계 편의 메서드 (선택)
        (User는 @Setter 허용이지만,

--- a/server/src/main/java/shinhan/mohaemoyong/server/dto/FriendRequestDto.java
+++ b/server/src/main/java/shinhan/mohaemoyong/server/dto/FriendRequestDto.java
@@ -1,0 +1,10 @@
+package shinhan.mohaemoyong.server.dto;
+
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter @Setter
+public class FriendRequestDto {
+    private Long receiverId;
+    private String message;
+}

--- a/server/src/main/java/shinhan/mohaemoyong/server/dto/FriendRequestResponse.java
+++ b/server/src/main/java/shinhan/mohaemoyong/server/dto/FriendRequestResponse.java
@@ -1,0 +1,31 @@
+package shinhan.mohaemoyong.server.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import shinhan.mohaemoyong.server.domain.FriendRequest;
+
+import java.time.Instant;
+
+@Getter
+@Builder
+@AllArgsConstructor
+public class FriendRequestResponse {
+    private Long requestId;
+    private Long requesterId;
+    private String requesterName;
+    private String status;
+    private String message;
+    private Instant createdAt;
+
+    public static FriendRequestResponse from(FriendRequest request) {
+        return FriendRequestResponse.builder()
+                .requestId(request.getRequestId())
+                .requesterId(request.getRequester().getId())
+                .requesterName(request.getRequester().getName())
+                .status(request.getStatus().name())
+                .message(request.getMessage())
+                .createdAt(request.getCreatedAt())
+                .build();
+    }
+}

--- a/server/src/main/java/shinhan/mohaemoyong/server/repository/FriendRequestRepository.java
+++ b/server/src/main/java/shinhan/mohaemoyong/server/repository/FriendRequestRepository.java
@@ -1,0 +1,12 @@
+package shinhan.mohaemoyong.server.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import shinhan.mohaemoyong.server.domain.FriendRequest;
+import shinhan.mohaemoyong.server.domain.User;
+
+import java.util.List;
+
+public interface FriendRequestRepository extends JpaRepository<FriendRequest, Long> {
+    boolean existsByRequesterAndReceiverAndStatus(User requester, User receiver, FriendRequest.Status status);
+    List<FriendRequest> findByReceiverAndStatus(User receiver, FriendRequest.Status status);
+}

--- a/server/src/main/java/shinhan/mohaemoyong/server/repository/FriendshipRepository.java
+++ b/server/src/main/java/shinhan/mohaemoyong/server/repository/FriendshipRepository.java
@@ -1,0 +1,24 @@
+package shinhan.mohaemoyong.server.repository;
+
+import jakarta.transaction.Transactional;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import shinhan.mohaemoyong.server.domain.Friendship;
+import shinhan.mohaemoyong.server.domain.User;
+
+import java.util.List;
+
+public interface FriendshipRepository extends JpaRepository<Friendship, Long> {
+    List<Friendship> findByUser(User user);
+
+    boolean existsByUserAndFriend(User user, User friend);
+
+    /** 양방향 관계 한번에 삭제 */
+    @Modifying
+    @Transactional
+    @Query("DELETE FROM Friendship f WHERE " +
+            "(f.user = :user AND f.friend = :friend) OR " +
+            "(f.user = :friend AND f.friend = :user)")
+    void deletePair(User user, User friend);
+}

--- a/server/src/main/java/shinhan/mohaemoyong/server/service/FriendRequestService.java
+++ b/server/src/main/java/shinhan/mohaemoyong/server/service/FriendRequestService.java
@@ -1,0 +1,146 @@
+package shinhan.mohaemoyong.server.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import shinhan.mohaemoyong.server.domain.FriendRequest;
+import shinhan.mohaemoyong.server.domain.Friendship;
+import shinhan.mohaemoyong.server.domain.User;
+import shinhan.mohaemoyong.server.dto.FriendRequestDto;
+import shinhan.mohaemoyong.server.dto.FriendRequestResponse;
+import shinhan.mohaemoyong.server.dto.FriendResponse;
+import shinhan.mohaemoyong.server.exception.ResourceNotFoundException;
+import shinhan.mohaemoyong.server.oauth2.security.UserPrincipal;
+import shinhan.mohaemoyong.server.repository.FriendRequestRepository;
+import shinhan.mohaemoyong.server.repository.FriendshipRepository;
+import shinhan.mohaemoyong.server.repository.UserRepository;
+
+import java.time.Instant;
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+public class FriendRequestService {
+
+    private final FriendRequestRepository friendRequestRepository;
+    private final FriendshipRepository friendshipRepository;
+    private final UserRepository userRepository;
+
+    /** 친구 요청 보내기 */
+    @Transactional
+    public FriendRequest sendRequest(UserPrincipal userPrincipal, FriendRequestDto dto) {
+        User requester = userRepository.findById(userPrincipal.getId())
+                .orElseThrow(() -> new IllegalArgumentException("요청자 유저 없음"));
+        User receiver = userRepository.findById(dto.getReceiverId())
+                .orElseThrow(() -> new IllegalArgumentException("받는 사람 유저 없음"));
+
+        if (requester.getId().equals(receiver.getId())) {
+            throw new IllegalArgumentException("자기 자신에게는 친구 요청을 보낼 수 없습니다.");
+        }
+
+        boolean alreadyPending = friendRequestRepository
+                .existsByRequesterAndReceiverAndStatus(requester, receiver, FriendRequest.Status.PENDING);
+        if (alreadyPending) {
+            throw new IllegalStateException("이미 보낸 요청이 있습니다.");
+        }
+
+        FriendRequest request = new FriendRequest();
+        request.setRequester(requester);
+        request.setReceiver(receiver);
+        request.setMessage(dto.getMessage());
+
+        return friendRequestRepository.save(request);
+    }
+
+    /** 받은 요청 목록 조회 */
+    @Transactional(readOnly = true)
+    public List<FriendRequestResponse> getReceivedRequests(UserPrincipal userPrincipal) {
+        User receiver = userRepository.findById(userPrincipal.getId())
+                .orElseThrow(() -> new IllegalArgumentException("User not found"));
+
+        List<FriendRequest> requests =
+                friendRequestRepository.findByReceiverAndStatus(receiver, FriendRequest.Status.PENDING);
+
+        return requests.stream()
+                .map(FriendRequestResponse::from)
+                .collect(Collectors.toList());
+    }
+
+    /** 친구 요청 수락 */
+    @Transactional
+    public FriendResponse acceptRequest(Long userId, Long requestId) {
+        FriendRequest request = friendRequestRepository.findById(requestId)
+                .orElseThrow(() -> new ResourceNotFoundException("FriendRequest", "id", requestId));
+
+        // 수신자가 본인인지 검증
+        if (!request.getReceiver().getId().equals(userId)) {
+            throw new AccessDeniedException("본인에게 온 요청만 수락할 수 있습니다.");
+        }
+
+        request.setStatus(FriendRequest.Status.ACCEPTED);
+        request.setRespondedAt(Instant.now());
+
+        // Friendship 저장 (양방향으로 저장하는 게 안전)
+        Friendship f1 = new Friendship();
+        f1.setUser(request.getRequester());
+        f1.setFriend(request.getReceiver());
+
+        Friendship f2 = new Friendship();
+        f2.setUser(request.getReceiver());
+        f2.setFriend(request.getRequester());
+
+        friendshipRepository.save(f1);
+        friendshipRepository.save(f2);
+
+        // Response로 변환
+        return FriendResponse.builder()
+                .id(request.getRequester().getId())
+                .name(request.getRequester().getName())
+                .email(request.getRequester().getEmail())
+                .imageUrl(request.getRequester().getImageUrl())
+                .build();
+    }
+
+    /** 친구 요청 거절 */
+    @Transactional
+    public void declineRequest(Long requestId, Long userId) {
+        FriendRequest request = friendRequestRepository.findById(requestId)
+                .orElseThrow(() -> new ResourceNotFoundException("FriendRequest", "id", requestId));
+
+        if (!request.getReceiver().getId().equals(userId)) {
+            throw new AccessDeniedException("해당 요청을 거절할 권한이 없습니다.");
+        }
+
+        if (request.getStatus() != FriendRequest.Status.PENDING) {
+            throw new IllegalStateException("이미 처리된 요청입니다.");
+        }
+
+        request.setStatus(FriendRequest.Status.DECLINED);
+        request.setRespondedAt(Instant.now());
+        friendRequestRepository.save(request);
+    }
+
+    /** 보낸 요청 취소 */
+    @Transactional
+    public void cancelRequest(Long requestId, Long userId) {
+        FriendRequest request = friendRequestRepository.findById(requestId)
+                .orElseThrow(() -> new ResourceNotFoundException("FriendRequest", "id", requestId));
+
+        if (!request.getRequester().getId().equals(userId)) {
+            throw new AccessDeniedException("자신이 보낸 요청만 취소할 수 있습니다.");
+        }
+
+        if (request.getStatus() != FriendRequest.Status.PENDING) {
+            throw new IllegalStateException("이미 처리된 요청은 취소할 수 없습니다.");
+        }
+
+        request.setStatus(FriendRequest.Status.CANCELED);
+        request.setIsActive(false);
+        request.setRespondedAt(Instant.now());
+
+        friendRequestRepository.save(request);
+    }
+
+}

--- a/server/src/main/java/shinhan/mohaemoyong/server/service/FriendService.java
+++ b/server/src/main/java/shinhan/mohaemoyong/server/service/FriendService.java
@@ -2,7 +2,13 @@ package shinhan.mohaemoyong.server.service;
 
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import shinhan.mohaemoyong.server.domain.Friendship;
+import shinhan.mohaemoyong.server.domain.User;
 import shinhan.mohaemoyong.server.dto.FriendResponse;
+import shinhan.mohaemoyong.server.oauth2.security.UserPrincipal;
+import shinhan.mohaemoyong.server.repository.FriendRequestRepository;
+import shinhan.mohaemoyong.server.repository.FriendshipRepository;
 import shinhan.mohaemoyong.server.repository.UserRepository;
 
 import java.util.List;
@@ -12,16 +18,44 @@ import java.util.stream.Collectors;
 @RequiredArgsConstructor
 public class FriendService {
 
+    private final FriendshipRepository friendshipRepository;
+    private final FriendRequestRepository friendRequestRepository;
     private final UserRepository userRepository;
 
-    public List<FriendResponse> getAllFriends() {
-        return userRepository.findAll().stream()
-                .map(user -> FriendResponse.builder()
-                        .id(user.getId())
-                        .name(user.getName())
-                        .email(user.getEmail())
-                        .imageUrl(user.getImageUrl())
-                        .build())
+    /** 현재 로그인 유저의 친구 목록 조회 */
+    @Transactional(readOnly = true)
+    public List<FriendResponse> getAllFriends(UserPrincipal userPrincipal) {
+        User me = userRepository.findById(userPrincipal.getId())
+                .orElseThrow(() -> new IllegalArgumentException("User not found: " + userPrincipal.getId()));
+
+        List<Friendship> friendships = friendshipRepository.findByUser(me);
+
+        return friendships.stream()
+                .map(f -> {
+                    User friend = f.getFriend();
+                    return FriendResponse.builder()
+                            .id(friend.getId())
+                            .name(friend.getName())
+                            .email(friend.getEmail())
+                            .imageUrl(friend.getImageUrl())
+                            .build();
+                })
                 .collect(Collectors.toList());
     }
+
+    // 친구 삭제
+    @Transactional
+    public void deleteFriend(Long userId, Long friendId) {
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new IllegalArgumentException("User not found"));
+        User friend = userRepository.findById(friendId)
+                .orElseThrow(() -> new IllegalArgumentException("Friend not found"));
+
+        if (!friendshipRepository.existsByUserAndFriend(user, friend)) {
+            throw new IllegalStateException("친구 관계가 존재하지 않습니다.");
+        }
+
+        friendshipRepository.deletePair(user, friend);
+    }
+
 }

--- a/server/src/main/java/shinhan/mohaemoyong/server/service/UserService.java
+++ b/server/src/main/java/shinhan/mohaemoyong/server/service/UserService.java
@@ -24,3 +24,4 @@ public class UserService {
 
 
 }
+


### PR DESCRIPTION
## 📌관련 이슈
- closed: #35
## 💥작업 내용
- 친구 요청 보내기 API 구현 (`POST /api/v1/friends/requests`)
- 받은 친구 요청 목록 조회 API 구현 (`GET /api/v1/friends/requests/inbox`)
- 친구 요청 수락 API 구현 (`POST /api/v1/friends/requests/{requestId}/accept`)
- 친구 요청 거절 API 구현 (`POST /api/v1/friends/requests/{requestId}/decline`)
- 친구 요청 취소 API 구현 (`POST /api/v1/friends/requests/{requestId}/cancel`)
- 친구 삭제 API 구현 (`DELETE /api/v1/friends/{friendId}`)
- FriendService와 FriendRequestService 로직 분리
- Friendship 양방향 저장 및 삭제 처리 로직 추가
## ✨참고 사항
- 요청/취소/거절 시 DB에서 삭제하지 않고 `status`와 `isActive`로 관리
- 친구 수락 시 양방향 `Friendship` 생성
- 친구 삭제 시 `FriendshipRepository.deletePair()`로 양방향 관계 동시 삭제


