### PR TITLE
[Server] feature : 댓글 삭제 API 개발

### DIFF
--- a/server/src/main/java/shinhan/mohaemoyong/server/controller/CommentController.java
+++ b/server/src/main/java/shinhan/mohaemoyong/server/controller/CommentController.java
@@ -5,15 +5,14 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
 import org.springframework.data.web.PageableDefault;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
 import shinhan.mohaemoyong.server.domain.User;
 import shinhan.mohaemoyong.server.dto.CommentCountResponse;
 import shinhan.mohaemoyong.server.dto.CommentListItemDto;
 import shinhan.mohaemoyong.server.oauth2.security.CurrentUser;
 import shinhan.mohaemoyong.server.oauth2.security.UserPrincipal;
+import shinhan.mohaemoyong.server.service.CommentCommandService;
 import shinhan.mohaemoyong.server.service.CommentCountService;
 import shinhan.mohaemoyong.server.service.CommentQueryService;
 
@@ -24,6 +23,7 @@ public class CommentController {
 
     private final CommentCountService commentCountService;
     private final CommentQueryService commentQueryService;
+    private final CommentCommandService commentCommandService;
 
     // 댓글 수 조회
     @GetMapping("/count")
@@ -42,5 +42,13 @@ public class CommentController {
     ) {
         return commentQueryService.getComments(planId, pageable, user);
 
+    }
+
+    @DeleteMapping("/{commentId}")
+    public ResponseEntity<Void> deleteComment(@PathVariable Long planId,
+                                              @PathVariable Long commentId,
+                                              @CurrentUser UserPrincipal me) {
+        commentCommandService.deleteComment(planId, commentId, me);
+        return ResponseEntity.noContent().build();
     }
 }

--- a/server/src/main/java/shinhan/mohaemoyong/server/domain/Comments.java
+++ b/server/src/main/java/shinhan/mohaemoyong/server/domain/Comments.java
@@ -63,4 +63,8 @@ public class Comments {
         photos.add(photo);
         if (photo.getComment() != this) photo.setCommentInternal(this);
     }
+
+    public void softDelete() {
+        this.deletedAt = LocalDateTime.now();
+    }
 }

--- a/server/src/main/java/shinhan/mohaemoyong/server/repository/CommentRepository.java
+++ b/server/src/main/java/shinhan/mohaemoyong/server/repository/CommentRepository.java
@@ -39,4 +39,16 @@ public interface CommentRepository extends JpaRepository<Comments, Long> {
            WHERE c.commentId IN :ids
            """)
     List<Comments> findWithUserByIdIn(@Param("ids") Collection<Long> ids);
+
+    /** planId로 Comment 들고오기 **/
+    @Query("""
+        select c
+        from Comments c
+        join fetch c.plan p
+        join fetch c.user u
+        where c.commentId = :commentId
+          and p.planId   = :planId
+          and c.deletedAt is null
+    """)
+    Optional<Comments> findActiveByIdAndPlanId(Long commentId, Long planId);
 }

--- a/server/src/main/java/shinhan/mohaemoyong/server/repository/PlanRepository.java
+++ b/server/src/main/java/shinhan/mohaemoyong/server/repository/PlanRepository.java
@@ -2,6 +2,7 @@ package shinhan.mohaemoyong.server.repository;
 
 import org.springframework.data.domain.Page;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import shinhan.mohaemoyong.server.domain.Plans;
@@ -61,4 +62,12 @@ public interface PlanRepository extends JpaRepository<Plans, Long> {
             @Param("endOfWeek") LocalDateTime endOfWeek
     );
 
+    /*댓글수 동기화*/
+    @Modifying
+    @Query("""
+        update Plans p
+           set p.commentCount = CASE WHEN p.commentCount > 0 THEN p.commentCount - 1 ELSE 0 END
+         where p.planId = :planId
+    """)
+    int decrementCommentCountSafely(Long planId);
 }

--- a/server/src/main/java/shinhan/mohaemoyong/server/service/CommentCommandService.java
+++ b/server/src/main/java/shinhan/mohaemoyong/server/service/CommentCommandService.java
@@ -1,0 +1,40 @@
+package shinhan.mohaemoyong.server.service;
+
+import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.crossstore.ChangeSetPersister;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Service;
+import org.springframework.web.server.ResponseStatusException;
+import shinhan.mohaemoyong.server.domain.Comments;
+import shinhan.mohaemoyong.server.oauth2.security.UserPrincipal;
+import shinhan.mohaemoyong.server.repository.CommentRepository;
+import shinhan.mohaemoyong.server.repository.PlanRepository;
+
+@Service
+@RequiredArgsConstructor
+public class CommentCommandService {
+
+    private final CommentRepository commentRepository;
+    private final PlanRepository planRepository;
+
+    @Transactional
+    public void deleteComment(Long planId, Long commentId, UserPrincipal me) {
+        Comments comment = commentRepository.findActiveByIdAndPlanId(commentId, planId)
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "댓글을 찾을 수 없거나 이미 삭제되었습니다."));
+
+        Long ownerId = comment.getUser().getId();
+        boolean isOwner = ownerId.equals(me.getId());
+        boolean isAdmin = me.getAuthorities().stream().anyMatch(a -> a.getAuthority().equals("ROLE_ADMIN"));
+
+        if (!isOwner && !isAdmin) {
+            throw new ResponseStatusException(HttpStatus.FORBIDDEN, "댓글 삭제 권한이 없습니다.");
+        }
+
+        // 소프트 삭제
+        comment.softDelete();
+
+        // 댓글 수 캐시 감소
+        planRepository.decrementCommentCountSafely(comment.getPlan().getPlanId());
+    }
+}


### PR DESCRIPTION
## 📌관련 이슈
- closed: #39 

## 💥작업 내용
- `DELETE /api/v1/plans/{planId}/comments/{commentId}` **댓글 삭제 API** 구현
    - 작성자/관리자 권한 체크 후 삭제 가능
    - 소프트 삭제(`comments.deleted_at` 세팅) 처리
    - `plans.comment_count` 감소 로직 추가 (최소 0 유지)
- 예외 처리:
    - 권한 없음 → 403 Forbidden
    - 존재하지 않거나 이미 삭제된 댓글 → 404 Not Found

## ✨참고 사항
- 삭제 성공 시 응답: **204 No Content** (바디 없음)
- 추후 이미지(CommentPhotos) 연쇄 soft delete 로직은 별도 이슈로 관리 예정

