### PR TITLE
refactor : 일정 및 친구 관련 API 수정

### DIFF
--- a/server/src/main/java/shinhan/mohaemoyong/server/controller/FriendPlanController.java
+++ b/server/src/main/java/shinhan/mohaemoyong/server/controller/FriendPlanController.java
@@ -2,6 +2,7 @@ package shinhan.mohaemoyong.server.controller;
 
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.*;
+import shinhan.mohaemoyong.server.dto.FriendPlanDto;
 import shinhan.mohaemoyong.server.dto.FriendWeeklyPlanDto;
 import shinhan.mohaemoyong.server.oauth2.security.CurrentUser;
 import shinhan.mohaemoyong.server.oauth2.security.UserPrincipal;
@@ -23,13 +24,8 @@ public class FriendPlanController {
         return friendPlanService.hasNewPlanThisWeek(userPrincipal.getId(), friendId);
     }
 
-    /** 친구 일정 확인 완료 (빨간테두리 제거) */
-    @PostMapping("/{friendId}/plans/seen")
-    public void markPlansAsSeen(@CurrentUser UserPrincipal userPrincipal,
-                                @PathVariable Long friendId) {
-        friendPlanService.markPlansAsSeen(userPrincipal.getId(), friendId);
-    }
 
+    // 친구 이번주 일정 불러오기
     @GetMapping("/{friendId}/plans/week")
     public List<FriendWeeklyPlanDto> getFriendWeeklyPlans(
             @CurrentUser UserPrincipal userPrincipal,
@@ -37,4 +33,11 @@ public class FriendPlanController {
         return friendPlanService.getFriendWeeklyPlansWithNewFlag(userPrincipal.getId(), friendId);
     }
 
+    // 친구 전체 일정 불러오기
+    @GetMapping("/{friendId}/plans")
+    public List<FriendPlanDto> getFriendAllPublicPlans(
+            @CurrentUser UserPrincipal userPrincipal,
+            @PathVariable Long friendId) {
+        return friendPlanService.getFriendAllPublicPlans(userPrincipal.getId(), friendId);
+    }
 }

--- a/server/src/main/java/shinhan/mohaemoyong/server/controller/HomeController.java
+++ b/server/src/main/java/shinhan/mohaemoyong/server/controller/HomeController.java
@@ -16,16 +16,17 @@ public class HomeController {
 
     private final HomeService homeService;
 
-    // GET /api/v1/home/plans/week?userId=1
+    // GET /api/v1/home/plans/week/myPlans
     // ✅ 내 일정 조회 (기존)
     @GetMapping("/plans/week/myPlans")
     public List<HomeWeekResponse> getThisWeekPlans(@CurrentUser UserPrincipal userPrincipal) {
         return homeService.getThisWeekPlans(userPrincipal.getId());
     }
 
-    // ✅ 친구 일정 조회
-    @GetMapping("/plans/week/friend/{friendId}")
-    public List<HomeWeekResponse> getFriendThisWeekPlans(@PathVariable Long friendId) {
-        return homeService.getThisWeekPlans(friendId);
+    // GET /api/v1/home/plans/myPlans
+    // 내 모든 일정 조회
+    @GetMapping("/plans/my")
+    public List<HomeWeekResponse> getAllPlans(@CurrentUser UserPrincipal userPrincipal) {
+        return homeService.getAllPlans(userPrincipal.getId());
     }
 }

--- a/server/src/main/java/shinhan/mohaemoyong/server/dto/FriendPlanDto.java
+++ b/server/src/main/java/shinhan/mohaemoyong/server/dto/FriendPlanDto.java
@@ -1,0 +1,18 @@
+package shinhan.mohaemoyong.server.dto;
+
+import java.time.LocalDateTime;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class FriendPlanDto {
+
+    private Long planId;
+    private String title;
+    private String place;
+    private LocalDateTime startTime;
+    private LocalDateTime endTime;
+}

--- a/server/src/main/java/shinhan/mohaemoyong/server/repository/FriendshipRepository.java
+++ b/server/src/main/java/shinhan/mohaemoyong/server/repository/FriendshipRepository.java
@@ -13,6 +13,7 @@ public interface FriendshipRepository extends JpaRepository<Friendship, Long> {
     List<Friendship> findByUser(User user);
 
     boolean existsByUserAndFriend(User user, User friend);
+    boolean existsByUserIdAndFriendId(Long userId, Long friendId);
 
     /** 양방향 관계 한번에 삭제 */
     @Modifying

--- a/server/src/main/java/shinhan/mohaemoyong/server/service/FriendPlanService.java
+++ b/server/src/main/java/shinhan/mohaemoyong/server/service/FriendPlanService.java
@@ -1,11 +1,15 @@
 package shinhan.mohaemoyong.server.service;
 
 import lombok.RequiredArgsConstructor;
+import org.springframework.security.access.AccessDeniedException;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 import shinhan.mohaemoyong.server.domain.FriendLastSeen;
 import shinhan.mohaemoyong.server.domain.Plans;
+import shinhan.mohaemoyong.server.dto.FriendPlanDto;
 import shinhan.mohaemoyong.server.dto.FriendWeeklyPlanDto;
 import shinhan.mohaemoyong.server.repository.FriendLastSeenRepository;
+import shinhan.mohaemoyong.server.repository.FriendshipRepository;
 import shinhan.mohaemoyong.server.repository.PlanRepository;
 
 import java.time.*;
@@ -16,23 +20,34 @@ import java.util.List;
 @RequiredArgsConstructor
 public class FriendPlanService {
 
+    private static final ZoneId ZONE = ZoneId.of("Asia/Seoul");
+
     private final PlanRepository planRepository;
     private final FriendLastSeenRepository lastSeenRepository;
+    private final FriendshipRepository friendshipRepository;
 
-    /**
-     * 이번주에 친구가 새 일정 등록했는지 확인 (빨간테두리 생성 여부)
-     */
+    // 공통 친구 검증
+    private void ensureFriendship(Long viewerId, Long friendId) {
+        boolean isFriend =
+                friendshipRepository.existsByUserIdAndFriendId(viewerId, friendId) ||
+                        friendshipRepository.existsByUserIdAndFriendId(friendId, viewerId);
+        if (!isFriend) throw new AccessDeniedException("친구 관계가 아닙니다.");
+    }
+
+    // 이번주 새로운 일정 여부 확인
+    @Transactional(readOnly = true)
     public boolean hasNewPlanThisWeek(Long userId, Long friendId) {
+        ensureFriendship(userId, friendId);
+
         ZoneId zone = ZoneId.of("Asia/Seoul");
         LocalDate today = LocalDate.now(zone);
 
-        LocalDate monday = today.with(TemporalAdjusters.previousOrSame(DayOfWeek.MONDAY));
-        LocalDate sunday = today.with(TemporalAdjusters.nextOrSame(DayOfWeek.SUNDAY));
+        // 🔥 오늘 ~ +7일 범위
+        LocalDateTime start = today.atStartOfDay();
+        LocalDateTime end   = today.plusDays(7).atTime(LocalTime.MAX);
 
-        LocalDateTime startOfWeek = monday.atStartOfDay();
-        LocalDateTime endOfWeek   = sunday.atTime(LocalTime.MAX);
-
-        List<Plans> recentPlans = planRepository.findRecentPublicPlansThisWeek(friendId, startOfWeek, endOfWeek);
+        List<Plans> recentPlans =
+                planRepository.findRecentPublicPlansWithinRange(friendId, start, end);
         if (recentPlans.isEmpty()) return false;
 
         FriendLastSeen lastSeen = lastSeenRepository
@@ -43,10 +58,12 @@ public class FriendPlanService {
                 .anyMatch(p -> p.getCreatedAt().isAfter(lastSeen.getLastSeenAt()));
     }
 
-    /**
-     * 친구 일정 확인 처리 → 빨간테두리 제거
-     */
+
+    // 친구 일정 확인 → lastSeen 업데이트
+    @Transactional
     public void markPlansAsSeen(Long userId, Long friendId) {
+        ensureFriendship(userId, friendId);
+
         FriendLastSeen lastSeen = lastSeenRepository
                 .findByUserIdAndFriendId(userId, friendId)
                 .orElse(new FriendLastSeen(userId, friendId, LocalDateTime.now()));
@@ -55,37 +72,58 @@ public class FriendPlanService {
         lastSeenRepository.save(lastSeen);
     }
 
-    /**
-     * 친구의 이번주 일정 조회 (일정별로 '새로운 일정 여부' 플래그 포함)
-     */
+    // 이번주 친구 일정 + isNew 플래그
+    @Transactional
     public List<FriendWeeklyPlanDto> getFriendWeeklyPlansWithNewFlag(Long userId, Long friendId) {
+        ensureFriendship(userId, friendId);
+
         ZoneId zone = ZoneId.of("Asia/Seoul");
         LocalDate today = LocalDate.now(zone);
 
-        LocalDate monday = today.with(TemporalAdjusters.previousOrSame(DayOfWeek.MONDAY));
-        LocalDate sunday = today.with(TemporalAdjusters.nextOrSame(DayOfWeek.SUNDAY));
+        // 🔥 오늘 ~ +7일 범위
+        LocalDateTime start = today.atStartOfDay();
+        LocalDateTime end   = today.plusDays(7).atTime(LocalTime.MAX);
 
-        LocalDateTime startOfWeek = monday.atStartOfDay();
-        LocalDateTime endOfWeek   = sunday.atTime(LocalTime.MAX);
+        List<Plans> plans = planRepository.findRecentPublicPlansWithinRange(friendId, start, end);
 
-        // 이번주 PUBLIC 일정
-        List<Plans> plans = planRepository.findRecentPublicPlansThisWeek(friendId, startOfWeek, endOfWeek);
-
-        // 내가 마지막으로 본 시각
         FriendLastSeen lastSeen = lastSeenRepository
                 .findByUserIdAndFriendId(userId, friendId)
                 .orElse(new FriendLastSeen(userId, friendId, LocalDateTime.MIN));
 
-        return plans.stream()
+        List<FriendWeeklyPlanDto> result = plans.stream()
                 .map(p -> FriendWeeklyPlanDto.builder()
                         .planId(p.getPlanId())
                         .title(p.getTitle())
                         .place(p.getPlace())
                         .startTime(p.getStartTime())
                         .endTime(p.getEndTime())
-                        .isNew(p.getCreatedAt().isAfter(lastSeen.getLastSeenAt())) // 새 일정 여부
-                        .build()
-                )
+                        .isNew(p.getCreatedAt().isAfter(lastSeen.getLastSeenAt()))
+                        .build())
                 .toList();
+
+        // 🔥 조회 후 자동 seen 처리
+        lastSeen.updateLastSeen(LocalDateTime.now());
+        lastSeenRepository.save(lastSeen);
+
+        return result;
     }
+
+
+    // 전체 공개 일정 조회
+    @Transactional
+    public List<FriendPlanDto> getFriendAllPublicPlans(Long viewerId, Long friendId) {
+        ensureFriendship(viewerId, friendId);
+
+        List<FriendPlanDto> plans = planRepository.findAllPublicPlansOfUser(friendId);
+
+        // 🔥 조회 후 자동 seen 처리
+        FriendLastSeen lastSeen = lastSeenRepository
+                .findByUserIdAndFriendId(viewerId, friendId)
+                .orElse(new FriendLastSeen(viewerId, friendId, LocalDateTime.now()));
+        lastSeen.updateLastSeen(LocalDateTime.now());
+        lastSeenRepository.save(lastSeen);
+
+        return plans;
+    }
+
 }

--- a/server/src/main/java/shinhan/mohaemoyong/server/service/HomeService.java
+++ b/server/src/main/java/shinhan/mohaemoyong/server/service/HomeService.java
@@ -15,6 +15,7 @@ public class HomeService {
 
     private final PlanRepository planRepository;
 
+    // 이번주 일정 조회
     public List<HomeWeekResponse> getThisWeekPlans(Long userId) {
         ZoneId zone = ZoneId.of("Asia/Seoul");
         LocalDate today = LocalDate.now(zone);
@@ -26,5 +27,10 @@ public class HomeService {
         LocalDateTime endOfWeek   = sunday.atTime(LocalTime.MAX);
 
         return planRepository.findWeeklyPlans(userId, startOfWeek, endOfWeek);
+    }
+
+    // 전체 일정 조회
+    public List<HomeWeekResponse> getAllPlans(Long userId) {
+        return planRepository.findAllPlansByUserId(userId);
     }
 }


### PR DESCRIPTION
## 📌관련 이슈
- closed: #38 
## 💥작업 내용
- 친구 일정 조회 시 오늘 기준 +7일(rolling window) 범위로 변경
- `FriendLastSeen` 엔티티 활용하여 친구 일정 확인 여부 기록
- 새로운 일정 등록 시 `isNew` 플래그 반환하도록 수정
- 조회 시 자동으로 `lastSeen` 갱신되도록 로직 개선
- 친구 전체 공개 일정 조회 API 수정 및 자동 seen 처리 추가
- 불필요해진 `/plans/seen` API 제거

## ✨참고 사항
- Postman으로 새로운 일정 등록 → 빨간 테두리 표시 → 일정 확인 후 사라짐 흐름 테스트 완료
- 프론트는 `/plans/new` 와 `/plans/week` 응답값(`new`) 활용해서 UI 반영


