### PR TITLE
[Server] feature : 금융 API headerDto 수정

### DIFF
--- a/server/src/main/java/shinhan/mohaemoyong/server/adapter/common/factory/HeaderFactory.java
+++ b/server/src/main/java/shinhan/mohaemoyong/server/adapter/common/factory/HeaderFactory.java
@@ -78,7 +78,10 @@ public class HeaderFactory {
     }
 
     private String createUniqueNo() {
-        return institutionCode + getTransmissionDate() + getTransmissionTime() +
+//        return institutionCode + getTransmissionDate() + getTransmissionTime() +
+//                ThreadLocalRandom.current().nextInt(100000, 1000000);
+
+        return this.getTransmissionDate() + this.getTransmissionTime() +
                 ThreadLocalRandom.current().nextInt(100000, 1000000);
     }
 }

--- a/server/src/main/java/shinhan/mohaemoyong/server/adapter/common/headerDto/BaseHeader.java
+++ b/server/src/main/java/shinhan/mohaemoyong/server/adapter/common/headerDto/BaseHeader.java
@@ -12,12 +12,12 @@ import lombok.experimental.SuperBuilder;
 @AllArgsConstructor
 public class BaseHeader {
     // 요청과 응답에 모두 포함되는 필드들
-    private String apiName;
-    private String transmissionDate;
-    private String transmissionTime;
-    private String institutionCode;
-    private String fintechAppNo;
-    private String apiServiceCode;
-    private String institutionTransactionUniqueNo;
+    private String apiName;                 // API 이름
+    private String transmissionDate;        // 전송일자
+    private String transmissionTime;        // 전송시각
+    private String institutionCode;         // 기관코드
+    private String fintechAppNo;            // 핀테크 앱 일련번호
+    private String apiServiceCode;          // API 서비스코드
+    private String institutionTransactionUniqueNo;  // 기관거래 고유번호
 
 }

--- a/server/src/main/java/shinhan/mohaemoyong/server/adapter/common/headerDto/ResponseHeader.java
+++ b/server/src/main/java/shinhan/mohaemoyong/server/adapter/common/headerDto/ResponseHeader.java
@@ -13,6 +13,6 @@ import lombok.AllArgsConstructor;
 @AllArgsConstructor
 public class ResponseHeader extends BaseHeader { // BaseHeader 상속
     // 응답에만 필요한 필드들
-    private String responseCode;
-    private String responseMessage;
+    private String responseCode;    // 응답코드
+    private String responseMessage; // 응답메세지
 }

--- a/server/src/main/java/shinhan/mohaemoyong/server/adapter/deposit/DemandDepositApiAdapter.java
+++ b/server/src/main/java/shinhan/mohaemoyong/server/adapter/deposit/DemandDepositApiAdapter.java
@@ -63,6 +63,7 @@ public class DemandDepositApiAdapter {
         } catch (Exception e) {
             // 3. API가 4xx 에러(H1000 등)를 반환했을 때 예외를 처리합니다.
             log.error("수시입출금 상품 등록 실패. 에러: {}", e.getMessage());
+            log.error("수시입출금 상품 등록 중 API 응답 처리 실패.", e);
             throw new RuntimeException("상품 등록에 실패했습니다.");
         }
     }

--- a/server/src/main/java/shinhan/mohaemoyong/server/adapter/deposit/dto/CreateDemandDepositRequest.java
+++ b/server/src/main/java/shinhan/mohaemoyong/server/adapter/deposit/dto/CreateDemandDepositRequest.java
@@ -10,7 +10,7 @@ import shinhan.mohaemoyong.server.adapter.common.headerDto.RequestHeader;
 @AllArgsConstructor
 public class CreateDemandDepositRequest {
     @JsonProperty("Header") // JSON 필드명 맵핑
-    private RequestHeader Header;
+    private RequestHeader header;
 
     private String bankCode;
     private String accountName;

--- a/server/src/main/java/shinhan/mohaemoyong/server/adapter/deposit/dto/CreateDemandDepositResponse.java
+++ b/server/src/main/java/shinhan/mohaemoyong/server/adapter/deposit/dto/CreateDemandDepositResponse.java
@@ -12,10 +12,10 @@ import java.util.List;
 @NoArgsConstructor
 public class CreateDemandDepositResponse {
     @JsonProperty("Header") // JSON 필드명과 Java 필드명을 매핑
-    private ResponseHeader Header;
+    private ResponseHeader header;
 
     @JsonProperty("REC") // JSON 필드명과 Java 필드명을 매핑
-    private List<Record> REC;
+    private Record REC;
 
     // REC 필드 내부의 객체를 표현하는 중첩 클래스
     @Getter


### PR DESCRIPTION
## 📌관련 이슈
- #47 
## 💥작업 내용
- JSON 변환시 Header 정보를 중복으로 가지고옴.
- REC 필트가 list로 설정되어있어 JSON 데이터가 정상적으로 파싱이 안됨.
- 기관거래고유번호 수정
- Header 필드를 header로 변경 후 중복을 제거
- Record REC 로 변경하여 정상적으로 파싱. 
- Header의 기관거래고유번호 return 값 수정
## ✨참고 사항
- 수시입출금-상품등록 API(createDemandDeposit) 개발 완료


