### PR TITLE
Feature/#55 댓글 등록 수정 api

### DIFF
--- a/server/src/main/java/shinhan/mohaemoyong/server/controller/CommentController.java
+++ b/server/src/main/java/shinhan/mohaemoyong/server/controller/CommentController.java
@@ -1,5 +1,6 @@
 package shinhan.mohaemoyong.server.controller;
 
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -11,6 +12,7 @@ import shinhan.mohaemoyong.server.domain.User;
 import shinhan.mohaemoyong.server.dto.CommentCountResponse;
 import shinhan.mohaemoyong.server.dto.CommentListItemDto;
 import shinhan.mohaemoyong.server.dto.CreateCommentRequest;
+import shinhan.mohaemoyong.server.dto.UpdateCommentRequest;
 import shinhan.mohaemoyong.server.oauth2.security.CurrentUser;
 import shinhan.mohaemoyong.server.oauth2.security.UserPrincipal;
 import shinhan.mohaemoyong.server.service.CommentCommandService;
@@ -45,12 +47,21 @@ public class CommentController {
 
     }
 
-
     @PostMapping
-    public ResponseEntity<Void> createComment(@PathVariable Long planId,
+    public ResponseEntity<Void> createComment (@PathVariable Long planId,
                                               @CurrentUser UserPrincipal me,
-                                              @RequestBody CreateCommentRequest req) {
+                                              @RequestBody @Valid CreateCommentRequest req) {
         commentCommandService.createComment(planId, me, req);
+        return ResponseEntity.noContent().build();
+    }
+
+
+    @PatchMapping("/{commentId}")
+    public ResponseEntity<Void> updateComment(@PathVariable Long planId,
+                                              @PathVariable Long commentId,
+                                              @CurrentUser UserPrincipal me,
+                                              @RequestBody @Valid UpdateCommentRequest req) {
+        commentCommandService.updateComment(planId, commentId, me, req);
         return ResponseEntity.noContent().build();
     }
 

--- a/server/src/main/java/shinhan/mohaemoyong/server/controller/DetailPlanController.java
+++ b/server/src/main/java/shinhan/mohaemoyong/server/controller/DetailPlanController.java
@@ -22,8 +22,7 @@ public class DetailPlanController {
             @CurrentUser UserPrincipal userPrincipal,
             @PathVariable Long planId
     ) {
-        Long loginUserId = userPrincipal.getId();
-        return ResponseEntity.ok(detailPlanService.getDetail(loginUserId, planId));
+        return ResponseEntity.ok(detailPlanService.getDetail(userPrincipal, planId));
     }
 
     // PATCH /api/v1/plans/{planId}
@@ -33,8 +32,7 @@ public class DetailPlanController {
             @PathVariable Long planId,
             @RequestBody DetailPlanUpdateRequest request
     ) {
-        Long loginUserId = userPrincipal.getId();
-        return ResponseEntity.ok(detailPlanService.update(loginUserId, planId, request));
+        return ResponseEntity.ok(detailPlanService.update(userPrincipal, planId, request));
     }
 
     // DELETE /api/v1/plans/{planId}
@@ -43,8 +41,7 @@ public class DetailPlanController {
             @CurrentUser UserPrincipal userPrincipal,
             @PathVariable Long planId
     ) {
-        Long loginUserId = userPrincipal.getId();
-        detailPlanService.delete(loginUserId, planId);
+        detailPlanService.delete(userPrincipal, planId);
         return ResponseEntity.noContent().build();
     }
 }

--- a/server/src/main/java/shinhan/mohaemoyong/server/domain/Comments.java
+++ b/server/src/main/java/shinhan/mohaemoyong/server/domain/Comments.java
@@ -75,6 +75,10 @@ public class Comments {
                 .build();
     }
 
+    public void updateContent(String newContent) {
+        this.content = newContent;
+    }
+
     // 단건 추가
     public Comments addPhoto(String url, Integer orderNo) {
         CommentPhotos p = CommentPhotos.create(url, orderNo);

--- a/server/src/main/java/shinhan/mohaemoyong/server/dto/UpdateCommentRequest.java
+++ b/server/src/main/java/shinhan/mohaemoyong/server/dto/UpdateCommentRequest.java
@@ -1,0 +1,26 @@
+package shinhan.mohaemoyong.server.dto;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import jakarta.validation.constraints.Size;
+import java.util.List;
+
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class UpdateCommentRequest {
+
+    @Size(max = 2000, message = "댓글은 2000자를 초과할 수 없습니다.")
+    private String content;
+
+    // 선택: 새로 추가할 이미지 URL들 (S3 업로드 결과)
+    private List<String> addImageUrls;
+
+    // 선택: 삭제할 댓글-이미지 row의 PK들
+    private List<Long> removeImageIds;
+
+    // getter/setter
+    public String getContent() { return content; }
+    public void setContent(String content) { this.content = content; }
+    public List<String> getAddImageUrls() { return addImageUrls; }
+    public void setAddImageUrls(List<String> addImageUrls) { this.addImageUrls = addImageUrls; }
+    public List<Long> getRemoveImageIds() { return removeImageIds; }
+    public void setRemoveImageIds(List<Long> removeImageIds) { this.removeImageIds = removeImageIds; }
+}

--- a/server/src/main/java/shinhan/mohaemoyong/server/repository/CommentRepository.java
+++ b/server/src/main/java/shinhan/mohaemoyong/server/repository/CommentRepository.java
@@ -52,6 +52,7 @@ public interface CommentRepository extends JpaRepository<Comments, Long> {
     """)
     Optional<Comments> findActiveByIdAndPlanId(Long commentId, Long planId);
 
-    Optional<Comments> findByIdAndPlan_PlanIdAndDeletedAtIsNull(Long commentId, Long planId);
+
+    Optional<Comments> findByCommentIdAndPlan_PlanIdAndDeletedAtIsNull(Long commentId, Long planId);
 
 }

--- a/server/src/main/java/shinhan/mohaemoyong/server/repository/CommentRepository.java
+++ b/server/src/main/java/shinhan/mohaemoyong/server/repository/CommentRepository.java
@@ -51,4 +51,7 @@ public interface CommentRepository extends JpaRepository<Comments, Long> {
           and c.deletedAt is null
     """)
     Optional<Comments> findActiveByIdAndPlanId(Long commentId, Long planId);
+
+    Optional<Comments> findByIdAndPlan_PlanIdAndDeletedAtIsNull(Long commentId, Long planId);
+
 }

--- a/server/src/main/java/shinhan/mohaemoyong/server/repository/FriendshipRepository.java
+++ b/server/src/main/java/shinhan/mohaemoyong/server/repository/FriendshipRepository.java
@@ -4,6 +4,7 @@ import jakarta.transaction.Transactional;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import shinhan.mohaemoyong.server.domain.Friendship;
 import shinhan.mohaemoyong.server.domain.User;
 
@@ -22,4 +23,12 @@ public interface FriendshipRepository extends JpaRepository<Friendship, Long> {
             "(f.user = :user AND f.friend = :friend) OR " +
             "(f.user = :friend AND f.friend = :user)")
     void deletePair(User user, User friend);
+
+    @Query("""
+        select case when count(f) > 0 then true else false end
+          from Friendship f
+         where (f.user.id = :a and f.friend.id = :b)
+            or (f.user.id = :b and f.friend.id = :a)
+    """)
+    boolean existsFriendEdge(@Param("a") Long a, @Param("b") Long b);
 }

--- a/server/src/main/java/shinhan/mohaemoyong/server/repository/PlanRepository.java
+++ b/server/src/main/java/shinhan/mohaemoyong/server/repository/PlanRepository.java
@@ -6,6 +6,7 @@ import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import shinhan.mohaemoyong.server.domain.Plans;
+import shinhan.mohaemoyong.server.domain.User;
 import shinhan.mohaemoyong.server.dto.FriendPlanDto;
 import shinhan.mohaemoyong.server.dto.HomeWeekResponse;
 
@@ -109,4 +110,5 @@ public interface PlanRepository extends JpaRepository<Plans, Long> {
     @Query("update Plans p set p.commentCount = coalesce(p.commentCount,0) + 1 where p.planId = :planId")
     int incrementCommentCount(@Param("planId") Long planId);
 
+    Long user(User user);
 }

--- a/server/src/main/java/shinhan/mohaemoyong/server/service/AccessControlService.java
+++ b/server/src/main/java/shinhan/mohaemoyong/server/service/AccessControlService.java
@@ -1,0 +1,24 @@
+package shinhan.mohaemoyong.server.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import shinhan.mohaemoyong.server.domain.Plans;
+import shinhan.mohaemoyong.server.oauth2.security.UserPrincipal;
+import shinhan.mohaemoyong.server.repository.FriendshipRepository;
+
+@Service
+@RequiredArgsConstructor
+public class AccessControlService {
+    private final FriendshipRepository friendshipRepository;
+
+    public boolean canViewPlan(Plans plan, UserPrincipal userPrincipal) {
+        if (plan.getUser().getId().equals(userPrincipal.getId())) return true;
+
+        return switch (plan.getPrivacyLevel()) {
+            case "PUBLIC" -> friendshipRepository.existsFriendEdge(userPrincipal.getId(), plan.getUser().getId());
+            case "PRIVATE" -> false;
+
+            default -> throw new IllegalStateException("Unexpected value: " + plan.getPrivacyLevel());
+        };
+    }
+}

--- a/server/src/main/java/shinhan/mohaemoyong/server/service/CommentCommandService.java
+++ b/server/src/main/java/shinhan/mohaemoyong/server/service/CommentCommandService.java
@@ -2,15 +2,21 @@ package shinhan.mohaemoyong.server.service;
 
 import jakarta.persistence.EntityNotFoundException;
 import jakarta.transaction.Transactional;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
 import org.springframework.web.server.ResponseStatusException;
+import shinhan.mohaemoyong.server.domain.CommentPhotos;
 import shinhan.mohaemoyong.server.domain.Comments;
 import shinhan.mohaemoyong.server.domain.Plans;
 import shinhan.mohaemoyong.server.domain.User;
 import shinhan.mohaemoyong.server.dto.CreateCommentRequest;
+import shinhan.mohaemoyong.server.dto.UpdateCommentRequest;
+import shinhan.mohaemoyong.server.exception.BadRequestException;
+import shinhan.mohaemoyong.server.exception.ResourceNotFoundException;
 import shinhan.mohaemoyong.server.oauth2.security.UserPrincipal;
+import shinhan.mohaemoyong.server.repository.CommentPhotoRepository;
 import shinhan.mohaemoyong.server.repository.CommentRepository;
 import shinhan.mohaemoyong.server.repository.PlanRepository;
 import shinhan.mohaemoyong.server.repository.UserRepository;
@@ -22,10 +28,12 @@ public class CommentCommandService {
     private final CommentRepository commentRepository;
     private final PlanRepository planRepository;
     private final UserRepository userRepository;
+    private final AccessControlService accessControlService;
+    private final CommentPhotoRepository commentPhotoRepository;
 
     @Transactional
-    public void createComment(Long planId, UserPrincipal me, CreateCommentRequest req) {
-        User user = userRepository.findById(me.getId())
+    public void createComment(Long planId, UserPrincipal userPrincipal, @Valid CreateCommentRequest req) {
+        User user = userRepository.findById(userPrincipal.getId())
                 .orElseThrow(() -> new EntityNotFoundException("유저를 찾을 수 없습니다."));
 
         Plans plan = planRepository.findById(planId)
@@ -34,8 +42,56 @@ public class CommentCommandService {
         Comments comment = Comments.create(plan, user, req.content())
                 .addPhotos(req.photos());
 
+        // plan 접근 권한 설정
+        if (!accessControlService.canViewPlan(plan, userPrincipal)) {
+            throw new ResourceNotFoundException("Plans", "planId", planId);
+        }
+
         commentRepository.save(comment);
         planRepository.incrementCommentCount(planId);
+    }
+
+    @Transactional
+    public void updateComment(Long planId, Long commentId, UserPrincipal me, UpdateCommentRequest req) {
+        // 1) 댓글 로드 (+소프트삭제 제외)
+        Comments comment = commentRepository
+                .findByIdAndPlan_PlanIdAndDeletedAtIsNull(commentId, planId)
+                .orElseThrow(() -> new ResourceNotFoundException("댓글을 찾을 수 없습니다."));
+
+        // 2) 권한 체크: 작성자 본인만 수정 (필요 시 관리자/플랜소유자 허용 로직 추가)
+        if (!comment.getUser().getId().equals(me.getId())) {
+            throw new ForbiddenException("댓글 수정 권한이 없습니다.");
+        }
+
+        // 3) 내용 수정 (null이면 무시)
+        if (req.getContent() != null) {
+            String newContent = req.getContent().trim();
+            if (newContent.isEmpty()) {
+                throw new BadRequestException("내용은 비어 있을 수 없습니다.");
+            }
+            comment.updateContent(newContent);
+        }
+
+        // 4) 이미지 추가
+        if (req.getAddImageUrls() != null && !req.getAddImageUrls().isEmpty()) {
+            int nextOrder = commentPhotoRepository.findMaxOrderNoByCommentId(commentId) + 1;
+
+            for (String url : req.getAddImageUrls()) {
+                CommentPhotos photo = CommentPhotos.create(url, nextOrder++);
+                photo.setCommentInternal(comment);             // 연관관계 주인 세팅
+                commentPhotosRepository.save(photo);           // 명시 저장
+            }
+        }
+
+        // 5) 이미지 삭제
+        if (req.getRemoveImageIds() != null && !req.getRemoveImageIds().isEmpty()) {
+            List<CommentImage> toDelete = commentImageRepository
+                    .findAllByIdInAndComment_CommentId(req.getRemoveImageIds(), comment.getCommentId());
+            if (toDelete.size() != req.getRemoveImageIds().size()) {
+                throw new BadRequestException("삭제 대상 이미지 중 존재하지 않는 항목이 있습니다.");
+            }
+            commentImageRepository.deleteAllInBatch(toDelete);
+        }
     }
 
     @Transactional

--- a/server/src/main/java/shinhan/mohaemoyong/server/service/DetailPlanService.java
+++ b/server/src/main/java/shinhan/mohaemoyong/server/service/DetailPlanService.java
@@ -7,6 +7,7 @@ import shinhan.mohaemoyong.server.domain.Plans;
 import shinhan.mohaemoyong.server.dto.DetailPlanResponse;
 import shinhan.mohaemoyong.server.dto.DetailPlanUpdateRequest;
 import shinhan.mohaemoyong.server.exception.ResourceNotFoundException;
+import shinhan.mohaemoyong.server.oauth2.security.UserPrincipal;
 import shinhan.mohaemoyong.server.repository.PlanRepository;
 
 import java.time.LocalDateTime;
@@ -17,23 +18,29 @@ import java.util.Set;
 public class DetailPlanService {
 
     private final PlanRepository planRepository;
+    private final AccessControlService accessControlService;
     private static final Set<String> PRIVACY_ALLOWED = Set.of("PUBLIC", "PRIVATE");
 
     @Transactional(readOnly = true)
-    public DetailPlanResponse getDetail(Long userId, Long planId) {
+    public DetailPlanResponse getDetail(UserPrincipal userPrincipal, Long planId) {
         // DetailPlanService.java
-        Plans p = planRepository.findDetailByOwner(userId, planId)
+        Plans p = planRepository.findDetailByOwner(userPrincipal.getId(), planId)
                 .orElseThrow(() ->
-                        new ResourceNotFoundException("Plans", "planId/userId", planId + "/" + userId)
+                        new ResourceNotFoundException("Plans", "planId/userId", planId + "/" + userPrincipal.getId())
                 );
+
+        // plan 접근 권한 설정
+        if (!accessControlService.canViewPlan(p, userPrincipal)) {
+            throw new ResourceNotFoundException("Plans", "planId", planId);
+        }
 
         return toResponse(p);
     }
 
     @Transactional
-    public DetailPlanResponse update(Long loginUserId, Long planId, DetailPlanUpdateRequest req) {
-        Plans p = planRepository.findDetailByOwner(loginUserId, planId)
-                .orElseThrow(() -> new ResourceNotFoundException("Plans", "planId/userId", planId + "/" + loginUserId));
+    public DetailPlanResponse update(UserPrincipal userPrincipal, Long planId, DetailPlanUpdateRequest req) {
+        Plans p = planRepository.findDetailByOwner(userPrincipal.getId(), planId)
+                .orElseThrow(() -> new ResourceNotFoundException("Plans", "planId/userId", planId + "/" + userPrincipal.getId()));
 
         if (p.isDeleted()) throw new ResourceNotFoundException("Plans", "planId", planId);
         if (req.startTime() != null && req.endTime() != null && req.startTime().isAfter(req.endTime()))
@@ -57,9 +64,10 @@ public class DetailPlanService {
     }
 
     @Transactional
-    public void delete(Long loginUserId, Long planId) {
-        Plans p = planRepository.findDetailByOwner(loginUserId, planId)
-                .orElseThrow(() -> new ResourceNotFoundException("Plans", "planId/userId", planId + "/" + loginUserId));
+    public void delete(UserPrincipal userPrincipal, Long planId) {
+        Plans p = planRepository.findDetailByOwner(userPrincipal.getId(), planId)
+                .orElseThrow(() -> new ResourceNotFoundException("Plans", "planId/userId", planId + "/" + userPrincipal.getId()));
+
         p.softDelete(LocalDateTime.now());
     }
 


### PR DESCRIPTION
## 📌관련 이슈
- closed: #55

## 💥작업 내용
- 댓글 등록 API 구현
    - 본문 + 첨부 이미지 등록 가능
    - 등록 시 `Plans.commentCount` 캐시 증가 처리
- 댓글 수정 API 구현
    - 본문 수정
    - 이미지 추가/삭제 처리 (orphanRemoval 활용)
    - 작성자 본인 권한 검증 로직 추가

## ✨참고 사항
- `commentId` 기준으로 조회 및 수정 처리
- 이미지 삭제 시 존재 여부 검증하여 BadRequest 반환
- Postman으로 정상 동작 확인 완료
