### PR TITLE
[Server] feature : 계좌 단일 조회 API 개발

### DIFF
--- a/server/src/main/java/shinhan/mohaemoyong/server/adapter/deposit/DemandDepositApiAdapter.java
+++ b/server/src/main/java/shinhan/mohaemoyong/server/adapter/deposit/DemandDepositApiAdapter.java
@@ -40,7 +40,7 @@ public class DemandDepositApiAdapter {
     public CreateDemandDepositResponse createDemandDeposit(String bankCode, String accountName, String accountDescription) {
         // 1. API 요청을 위한 URL 준비합니다.
         String url = baseUrl + "/ssafy/api/v1/edu/demandDeposit/createDemandDeposit";
-        
+
         // HeaderFactory를 사용하여 공통 헤더를 생성합니다. (userKey 제외)
         RequestHeader header = headerFactory.createHeader("createDemandDeposit");
 
@@ -184,7 +184,7 @@ public class DemandDepositApiAdapter {
      * @return 조회된 계좌 목록 정보가 담긴 DTO
      */
     public InquireDemandDepositAccountListResponse inquireDemandDepositAccountList(String userKey) {
-        // 1. API 요청을 위한 URL과 Body를 준비합니다. [cite: 1]
+        // 1. API 요청을 위한 URL과 Body를 준비합니다.
         String url = baseUrl + "/ssafy/api/v1/edu/demandDeposit/inquireDemandDepositAccountList";
 
         // 이 API는 userKey를 포함하므로, 파라미터가 2개인 createHeader 메서드를 사용합니다.

--- a/server/src/main/java/shinhan/mohaemoyong/server/controller/AccountController.java
+++ b/server/src/main/java/shinhan/mohaemoyong/server/controller/AccountController.java
@@ -1,0 +1,29 @@
+package shinhan.mohaemoyong.server.controller;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import shinhan.mohaemoyong.server.dto.SearchAccountResponseDto;
+import shinhan.mohaemoyong.server.oauth2.security.CurrentUser;
+import shinhan.mohaemoyong.server.oauth2.security.UserPrincipal;
+import shinhan.mohaemoyong.server.service.AccountService;
+import java.util.List;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/account")
+public class AccountController {
+
+    private final AccountService accountService;
+
+    @GetMapping("/savingState")
+    public ResponseEntity<List<SearchAccountResponseDto>> getSavingState(
+            @CurrentUser UserPrincipal userPrincipal
+    ) {
+        // ✨ userPrincipal.getId() 대신 userPrincipal 객체 자체를 전달
+        List<SearchAccountResponseDto> response = accountService.getSavingStateList(userPrincipal);
+        return ResponseEntity.ok(response);
+    }
+}

--- a/server/src/main/java/shinhan/mohaemoyong/server/domain/Accounts.java
+++ b/server/src/main/java/shinhan/mohaemoyong/server/domain/Accounts.java
@@ -45,6 +45,9 @@ public class Accounts {
     @Column(name = "account_expiry_date")
     private LocalDate accountExpiryDate;
 
+    @Column(name = "target_amount")
+    private Long targetAmount; // ✨ 목표 금액 필드 추가, 달성률을 나타내기 위함, 조현우
+
     @CreationTimestamp
     @Column(name = "created_at", updatable = false)
     private Instant createdAt;

--- a/server/src/main/java/shinhan/mohaemoyong/server/dto/SearchAccountResponseDto.java
+++ b/server/src/main/java/shinhan/mohaemoyong/server/dto/SearchAccountResponseDto.java
@@ -1,0 +1,19 @@
+package shinhan.mohaemoyong.server.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+import java.util.List;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class SearchAccountResponseDto {
+    private String accountNumber;      // 계좌번호
+    private Long balance;              // 잔여금액
+    private String accountAlias;       // 계좌별칭
+    private List<WeeklySavingDto> monthlySavings; // 월별 저축 금액
+    private Double achievementRate;    // 계좌 저축금액 달성률
+}
+
+

--- a/server/src/main/java/shinhan/mohaemoyong/server/dto/WeeklySavingDto.java
+++ b/server/src/main/java/shinhan/mohaemoyong/server/dto/WeeklySavingDto.java
@@ -1,0 +1,11 @@
+package shinhan.mohaemoyong.server.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class WeeklySavingDto {
+    private String weekDescription;
+    private Long amount;
+}

--- a/server/src/main/java/shinhan/mohaemoyong/server/repository/AccountRepository.java
+++ b/server/src/main/java/shinhan/mohaemoyong/server/repository/AccountRepository.java
@@ -1,0 +1,17 @@
+package shinhan.mohaemoyong.server.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import shinhan.mohaemoyong.server.domain.Accounts;
+import shinhan.mohaemoyong.server.domain.User;
+
+import java.util.List;
+
+public interface AccountRepository extends JpaRepository<Accounts, Long> {
+
+    /**
+     * 특정 사용자가 소유한 모든 계좌를 조회합니다.
+     * @param user 조회할 User 엔티티
+     * @return 해당 사용자의 Accounts 목록
+     */
+    List<Accounts> findAllByUser(User user);
+}

--- a/server/src/main/java/shinhan/mohaemoyong/server/service/AccountService.java
+++ b/server/src/main/java/shinhan/mohaemoyong/server/service/AccountService.java
@@ -1,0 +1,120 @@
+package shinhan.mohaemoyong.server.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import shinhan.mohaemoyong.server.adapter.deposit.DemandDepositApiAdapter;
+import shinhan.mohaemoyong.server.adapter.deposit.dto.InquireDemandDepositAccountListResponse;
+import shinhan.mohaemoyong.server.adapter.deposit.dto.InquireTransactionHistoryListResponse;
+import shinhan.mohaemoyong.server.domain.Accounts;
+import shinhan.mohaemoyong.server.domain.User;
+import shinhan.mohaemoyong.server.repository.AccountRepository;
+import shinhan.mohaemoyong.server.repository.UserRepository;
+import shinhan.mohaemoyong.server.dto.SearchAccountResponseDto;
+import shinhan.mohaemoyong.server.dto.WeeklySavingDto;
+import shinhan.mohaemoyong.server.oauth2.security.UserPrincipal;
+import shinhan.mohaemoyong.server.service.financedto.InquireTransactionHistoryListRequestDto;
+
+import java.time.DayOfWeek;
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
+import java.time.temporal.WeekFields;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+/**
+ * 계좌 관련 비즈니스 로직을 처리하는 서비스 클래스
+ */
+@Service
+@RequiredArgsConstructor
+public class AccountService {
+
+    private final AccountRepository accountsRepository;
+    private final UserRepository userRepository;
+    private final DemandDepositApiAdapter demandDepositApiAdapter;
+
+    /**
+     * 사용자의 모든 계좌에 대한 저축 현황을 조회합니다.
+     * @param userPrincipal 현재 로그인한 사용자 정보
+     * @return 각 계좌별 저축 현황 DTO 목록
+     */
+    @Transactional(readOnly = true)
+    public List<SearchAccountResponseDto> getSavingStateList(UserPrincipal userPrincipal) {
+        // 1. userPrincipal 객체에서 userId 추출
+        Long userId = userPrincipal.getId();
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new RuntimeException("사용자를 찾을 수 없습니다."));
+
+        // 2. DB에서 해당 사용자의 모든 계좌 목록 조회
+        List<Accounts> userAccounts = accountsRepository.findAllByUser(user);
+
+        // 3. (효율성을 위해) 금융 API로 모든 계좌의 현재 잔액을 한번에 조회
+        InquireDemandDepositAccountListResponse accountListResponse = demandDepositApiAdapter.inquireDemandDepositAccountList(user.getUserkey());
+
+        Map<String, Long> balanceMap = accountListResponse.getREC().stream()
+                .collect(Collectors.toMap(InquireDemandDepositAccountListResponse.Record::getAccountNo, InquireDemandDepositAccountListResponse.Record::getAccountBalance));
+
+        // 4. 각 계좌별로 순회하며 최종 응답 DTO 리스트 생성
+        return userAccounts.stream().map(account -> {
+            Long currentBalance = balanceMap.getOrDefault(account.getAccountNumber(), 0L);
+            Long targetAmount = account.getTargetAmount();
+
+            // 4-1. 월별 저축액 계산 (금융 API 호출)
+            List<WeeklySavingDto> weeklySavings = calculateWeeklySavings(user.getUserkey(), account.getAccountNumber());
+
+            // 4-2. 달성률 계산
+            double achievementRate = (targetAmount == null || targetAmount == 0) ? 0.0 : ((double) currentBalance / targetAmount) * 100.0;
+
+            // 4-3. 최종 DTO 빌드
+            return SearchAccountResponseDto.builder()
+                    .accountNumber(account.getAccountNumber())
+                    .balance(currentBalance)
+                    .accountAlias(account.getAccountName())
+                    .monthlySavings(weeklySavings)
+                    .achievementRate(achievementRate)
+                    .build();
+        }).collect(Collectors.toList());
+    }
+
+    /**
+     * Helper Method: 특정 계좌의 거래 내역 API를 호출하여 주차별 입금액을 계산
+     */
+    private List<WeeklySavingDto> calculateWeeklySavings(String userKey, String accountNumber) {
+        LocalDate today = LocalDate.now();
+        String startDate = today.withDayOfMonth(1).format(DateTimeFormatter.ofPattern("yyyyMMdd"));
+        String endDate = today.format(DateTimeFormatter.ofPattern("yyyyMMdd"));
+
+        InquireTransactionHistoryListRequestDto requestDto = new InquireTransactionHistoryListRequestDto(
+                accountNumber, startDate, endDate, "M", "ASC" // M: 입금만 조회
+        );
+
+        InquireTransactionHistoryListResponse historyResponse = demandDepositApiAdapter.inquireTransactionHistoryList(userKey, requestDto);
+
+        if (historyResponse.getREC() == null || historyResponse.getREC().getList() == null) {
+            return new ArrayList<>();
+        }
+
+        Map<String, Long> weeklySum = historyResponse.getREC().getList().stream()
+                .collect(Collectors.groupingBy(
+                        transaction -> getWeekOfMonth(transaction.getTransactionDate()),
+                        Collectors.summingLong(InquireTransactionHistoryListResponse.Transaction::getTransactionBalance)
+                ));
+
+        return weeklySum.entrySet().stream()
+                .map(entry -> new WeeklySavingDto(entry.getKey(), entry.getValue()))
+                .collect(Collectors.toList());
+    }
+
+    /**
+     * Helper Method: YYYYMMDD 형식의 날짜를 "M월 N주차" 형식으로 변환
+     */
+    private String getWeekOfMonth(String yyyymmdd) {
+        LocalDate date = LocalDate.parse(yyyymmdd, DateTimeFormatter.ofPattern("yyyyMMdd"));
+        int month = date.getMonthValue();
+        WeekFields weekFields = WeekFields.of(DayOfWeek.SUNDAY, 1);
+        int weekOfMonth = date.get(weekFields.weekOfMonth());
+        return String.format("%d월 %d주", month, weekOfMonth);
+    }
+}

--- a/server/src/test/java/shinhan/mohaemoyong/server/adapter/deposit/DemandDepositApiAdapterTest.java
+++ b/server/src/test/java/shinhan/mohaemoyong/server/adapter/deposit/DemandDepositApiAdapterTest.java
@@ -6,6 +6,11 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import shinhan.mohaemoyong.server.adapter.deposit.dto.CreateDemandDepositResponse;
+import shinhan.mohaemoyong.server.adapter.deposit.dto.InquireDemandDepositAccountListResponse;
+import shinhan.mohaemoyong.server.adapter.deposit.dto.InquireTransactionHistoryListResponse;
+import shinhan.mohaemoyong.server.service.financedto.InquireTransactionHistoryListRequestDto;
+
+import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
@@ -30,6 +35,70 @@ class DemandDepositApiAdapterTest {
         // then - 결과 검증 및 로그 출력
         log.info("응답 코드: {}", response.getHeader().getResponseCode());
         log.info("등록된 상품명: {}", response.getREC().getAccountName());
+
+        // 응답 객체가 null이 아닌지 간단히 검증
+        assertNotNull(response);
+        assertNotNull(response.getHeader());
+    }
+
+    @Test
+    @DisplayName("수시입출금 계좌 목록 조회 API 호출 테스트") // 테스트에 한글 이름 붙이기
+    void 수시입출금_계좌_목록_조회_API_호출_테스트() {
+        // given - 테스트에 필요한 값들을 하드코딩으로 준비
+        String userKey = "c50e9509-6583-45ba-9ed7-21e53e06be57";
+
+        // when - 실제 어댑터 메서드 호출
+        InquireDemandDepositAccountListResponse response =  demandDepositApiAdapter.inquireDemandDepositAccountList(userKey);
+
+        // then - 결과 검증 및 로그 출력
+        log.info("응답 코드: {}", response.getHeader().getResponseCode());
+
+        // 계좌목록 출력
+            List<InquireDemandDepositAccountListResponse.Record> records = response.getREC();
+
+        if (records != null) {
+            records.stream().map(record -> record.getAccountName())
+            .forEach(accountname -> log.info("계좌이름 : {}", accountname));
+        }
+
+
+        // 응답 객체가 null이 아닌지 간단히 검증
+        assertNotNull(response);
+        assertNotNull(response.getHeader());
+    }
+
+    @Test
+    @DisplayName("수시입출금 계좌거래내역조회 API 호출 테스트") // 테스트에 한글 이름 붙이기
+    void 수시입출금_계좌거래내역조회_API_호출_테스트() {
+        // given - 테스트에 필요한 값들을 DTO로 준비
+        String userKey = "c50e9509-6583-45ba-9ed7-21e53e06be57";
+
+        // 예시 DTO 생성
+        InquireTransactionHistoryListRequestDto requestDto = new InquireTransactionHistoryListRequestDto(
+                "0017140134561303", // 조회할 계좌번호
+                "20250721",         // 조회 시작일
+                "20250820",         // 조회 종료일
+                "A",                // 거래 구분 (전체)
+                "ASC"               // 정렬 순서 (오름차순)
+        );
+        
+
+        // when - 실제 어댑터 메서드 호출
+        InquireTransactionHistoryListResponse response =  demandDepositApiAdapter.inquireTransactionHistoryList(userKey, requestDto);
+
+            
+        // then - 결과 검증 및 로그 출력
+        log.info("응답 코드: {}", response.getHeader().getResponseCode());
+
+        // 계좌목록 출력
+        List<InquireTransactionHistoryListResponse.Transaction> records = response.getREC().getList();
+
+        log.info("총 거래 건수 : {}", response.getREC().getTotalCount());
+
+        if (records != null) {
+            records.stream().map(record -> record.getTransactionUniqueNo())
+                    .forEach(transactionuniqueNo -> log.info("거래고유번호 : {}", transactionuniqueNo));
+        }
 
         // 응답 객체가 null이 아닌지 간단히 검증
         assertNotNull(response);


### PR DESCRIPTION
## 📌관련 이슈
- closed: #70 
## 💥작업 내용
- AccountController, AccountService, AccountRepository 개발
- SearchAccountResponseDto(계좌조회응답에 필요한 Dto),  WeeklySavingDto(프론트 응답에 사용할 Dto, 주차별 저축금액을 표시)
- Accounts 칼럼추가 : 계좌별 목표금액을 표시하기 위함
## ✨참고 사항
- token을 사용해서 로그인하면 userkey 값이 provieder_id 와 같았음. 추후 서버 DB에서 확인필요함.
- test 파일도 추가했음. 배포시 test 파일 제외 배포 필요


