### PR TITLE
modify : 다중 미디어 업로드 로직 수정

### DIFF
--- a/server/src/main/java/shinhan/mohaemoyong/server/controller/MediaUploadDirectController.java
+++ b/server/src/main/java/shinhan/mohaemoyong/server/controller/MediaUploadDirectController.java
@@ -1,6 +1,7 @@
 package shinhan.mohaemoyong.server.controller;
 
 import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
@@ -9,20 +10,48 @@ import shinhan.mohaemoyong.server.oauth2.security.CurrentUser;
 import shinhan.mohaemoyong.server.oauth2.security.UserPrincipal;
 import shinhan.mohaemoyong.server.service.MediaUploadDirectService;
 
+import java.util.List;
+
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/v1/uploads/media")
 public class MediaUploadDirectController {
 
     private final MediaUploadDirectService service;
+    @Value("${app.upload.maxCount:5}")
+    private int maxCount;
 
     // Multipart 업로드 (form-data)
-    @PostMapping(value = "/direct", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+    @PostMapping(value = "/direct", consumes = MediaType.MULTIPART_FORM_DATA_VALUE, produces = MediaType.APPLICATION_JSON_VALUE)
     public ResponseEntity<?> uploadDirect(
             @RequestParam("file") MultipartFile file,
             @CurrentUser UserPrincipal user
     ) {
         var res = service.upload(file, user.getId());
         return ResponseEntity.ok(res);
+    }
+
+
+    // 2) 다중 파일 업로드
+    @PostMapping(value = "/direct/batch", consumes = MediaType.MULTIPART_FORM_DATA_VALUE, produces = MediaType.APPLICATION_JSON_VALUE)
+    public ResponseEntity<List<MediaUploadDirectService.UploadResult>> uploadDirectBatch(
+            @RequestParam("files") List<MultipartFile> files,
+            @CurrentUser UserPrincipal user
+    ) {
+        if (files == null || files.isEmpty()) {
+            throw new IllegalArgumentException("업로드할 파일이 없습니다.");
+        }
+        if (files.size() > maxCount) {
+            throw new IllegalArgumentException("최대 " + maxCount + "개까지 업로드할 수 있습니다.");
+        }
+
+        Long uploaderId = user.getId();
+
+        // 순차 처리
+        List<MediaUploadDirectService.UploadResult> results = files.stream()
+                .map(f -> service.upload(f, uploaderId))
+                .toList();
+
+        return ResponseEntity.ok(results);
     }
 }

--- a/server/src/main/java/shinhan/mohaemoyong/server/domain/PlanPhotos.java
+++ b/server/src/main/java/shinhan/mohaemoyong/server/domain/PlanPhotos.java
@@ -2,6 +2,7 @@ package shinhan.mohaemoyong.server.domain;
 
 import jakarta.persistence.*;
 import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.hibernate.annotations.CreationTimestamp;
@@ -9,6 +10,7 @@ import org.hibernate.annotations.UpdateTimestamp;
 import shinhan.mohaemoyong.server.domain.Plans;
 
 import java.time.Instant;
+import java.util.Objects;
 
 @Entity
 @Table(name = "plan_photos")
@@ -48,4 +50,26 @@ public class PlanPhotos {
 
     // 내부 전용
     void setPlanInternal(Plans plan) { this.plan = plan; }
+
+    @Builder
+    private PlanPhotos(Plans plan, String photoUrl, Integer orderNo, Integer width, Integer height) {
+        this.plan = plan;
+        this.photoUrl = photoUrl;
+        this.orderNo = (orderNo != null) ? orderNo : 0;
+        this.width = width;
+        this.height = height;
+    }
+    public static PlanPhotos create(Plans plan, String url, Integer orderNo, Integer width, Integer height) {
+        // ✅ 빌더 대신 명시적 생성자 호출 (plan 절대 null 아님 보장)
+        return new PlanPhotos(Objects.requireNonNull(plan, "plan"),
+                Objects.requireNonNull(url, "url"),
+                orderNo, width, height);
+    }
+
+    public void updateAttributes(String url, Integer orderNo, Integer width, Integer height) {
+        if (url != null && !url.isBlank()) this.photoUrl = url;
+        if (orderNo != null) this.orderNo = orderNo;
+        if (width != null) this.width = width;
+        if (height != null) this.height = height;
+    }
 }

--- a/server/src/main/java/shinhan/mohaemoyong/server/dto/DetailPlanResponse.java
+++ b/server/src/main/java/shinhan/mohaemoyong/server/dto/DetailPlanResponse.java
@@ -1,6 +1,7 @@
 package shinhan.mohaemoyong.server.dto;
 
 import java.time.LocalDateTime;
+import java.util.List;
 
 public record DetailPlanResponse(
         Long planId,
@@ -16,5 +17,14 @@ public record DetailPlanResponse(
         boolean hasSavingsGoal,
         Integer savingsAmount,
         String privacyLevel,
-        Integer commentCount
-) {}
+        Integer commentCount,
+        List<PhotoDto> photos
+) {
+    public record PhotoDto(
+            Long photoId,
+            String url,
+            Integer orderNo,
+            Integer width,
+            Integer height
+    ) {}
+}

--- a/server/src/main/java/shinhan/mohaemoyong/server/dto/DetailPlanUpdateRequest.java
+++ b/server/src/main/java/shinhan/mohaemoyong/server/dto/DetailPlanUpdateRequest.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.annotation.JsonInclude;
 
 import java.time.LocalDateTime;
 
+import java.util.List;
 @JsonInclude(JsonInclude.Include.NON_NULL)
 public record DetailPlanUpdateRequest(
         String title,
@@ -15,5 +16,14 @@ public record DetailPlanUpdateRequest(
         Boolean isCompleted,
         Boolean hasSavingsGoal,
         Integer savingsAmount,
-        String privacyLevel   // "PRIVATE" | "PUBLIC"
-) {}
+        String privacyLevel,   // "PRIVATE" | "PUBLIC"
+        List<UpdatePhotoItem> photos
+) {
+    public record UpdatePhotoItem(
+        Long photoId,
+        String url,
+        Integer orderNo,
+        Integer width,
+        Integer height
+    ) {}
+}

--- a/server/src/main/java/shinhan/mohaemoyong/server/repository/PlanPhotoRepository.java
+++ b/server/src/main/java/shinhan/mohaemoyong/server/repository/PlanPhotoRepository.java
@@ -1,0 +1,14 @@
+package shinhan.mohaemoyong.server.repository;
+
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import shinhan.mohaemoyong.server.domain.PlanPhotos;
+
+import java.util.List;
+
+public interface PlanPhotoRepository extends JpaRepository<PlanPhotos, Long> {
+    List<PlanPhotos> findByPlan_PlanIdOrderByOrderNoAscPlanPhotoIdAsc(Long planId);
+
+    // 치환 시 “남아있지 않은 기존 사진 일괄 삭제”에 사용
+    void deleteByPlan_PlanIdAndPlanPhotoIdIn(Long planId, List<Long> ids);
+}

--- a/server/src/main/java/shinhan/mohaemoyong/server/service/DetailPlanService.java
+++ b/server/src/main/java/shinhan/mohaemoyong/server/service/DetailPlanService.java
@@ -3,15 +3,18 @@ package shinhan.mohaemoyong.server.service;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import shinhan.mohaemoyong.server.domain.PlanPhotos;
 import shinhan.mohaemoyong.server.domain.Plans;
 import shinhan.mohaemoyong.server.dto.DetailPlanResponse;
 import shinhan.mohaemoyong.server.dto.DetailPlanUpdateRequest;
 import shinhan.mohaemoyong.server.exception.ResourceNotFoundException;
 import shinhan.mohaemoyong.server.oauth2.security.UserPrincipal;
+import shinhan.mohaemoyong.server.repository.PlanPhotoRepository;
 import shinhan.mohaemoyong.server.repository.PlanRepository;
 
 import java.time.LocalDateTime;
-import java.util.Set;
+import java.util.*;
+import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
@@ -19,6 +22,7 @@ public class DetailPlanService {
 
     private final PlanRepository planRepository;
     private final AccessControlService accessControlService;
+    private final PlanPhotoRepository planPhotoRepository;
     private static final Set<String> PRIVACY_ALLOWED = Set.of("PUBLIC", "PRIVATE");
 
     @Transactional(readOnly = true)
@@ -34,7 +38,11 @@ public class DetailPlanService {
             throw new ResourceNotFoundException("Plans", "planId", planId);
         }
 
-        return toResponse(p);
+        // 사진들 조회 (정렬 보장)
+        List<PlanPhotos> photos = planPhotoRepository
+                .findByPlan_PlanIdOrderByOrderNoAscPlanPhotoIdAsc(planId);
+
+        return toResponse(p, photos);
     }
 
     @Transactional
@@ -43,25 +51,134 @@ public class DetailPlanService {
                 .orElseThrow(() -> new ResourceNotFoundException("Plans", "planId/userId", planId + "/" + userPrincipal.getId()));
 
         if (p.isDeleted()) throw new ResourceNotFoundException("Plans", "planId", planId);
-        if (req.startTime() != null && req.endTime() != null && req.startTime().isAfter(req.endTime()))
+        if (req.startTime() != null && req.endTime() != null && req.startTime().isAfter(req.endTime())) {
             throw new IllegalArgumentException("startTime must be before endTime");
+        }
 
+        // privacyLevel 정규화
         if (req.privacyLevel() != null) {
             String normalized = req.privacyLevel().trim().toUpperCase();
             if (!PRIVACY_ALLOWED.contains(normalized)) {
                 throw new IllegalArgumentException("privacyLevel must be one of " + PRIVACY_ALLOWED);
             }
-
             req = new DetailPlanUpdateRequest(
                     req.title(), req.content(), req.imageUrl(), req.place(),
                     req.startTime(), req.endTime(), req.isCompleted(),
-                    req.hasSavingsGoal(), req.savingsAmount(), normalized
+                    req.hasSavingsGoal(), req.savingsAmount(), normalized,
+                    req.photos()
             );
         }
 
+        // 1) 스칼라 필드 갱신 (엔티티 도메인 메서드 사용, 세터 금지)
         p.applyUpdate(req, LocalDateTime.now());
-        return toResponse(p);
+
+        // 2) 사진 치환: 요청에 photos가 들어온 경우에만 수행
+        if (req.photos() != null) {
+            // 현재 사진 조회 및 맵 구성
+            List<PlanPhotos> current =
+                    planPhotoRepository.findByPlan_PlanIdOrderByOrderNoAscPlanPhotoIdAsc(planId);
+
+            Map<Long, PlanPhotos> currentById = current.stream()
+                    .filter(ph -> ph.getPlanPhotoId() != null)
+                    .collect(Collectors.toMap(PlanPhotos::getPlanPhotoId, ph -> ph));
+
+            // 중복 photoId 방지
+            var seen = new HashSet<Long>();
+            for (var it : req.photos()) {
+                if (it.photoId() != null && !seen.add(it.photoId())) {
+                    throw new IllegalArgumentException("Duplicated photoId in request: " + it.photoId());
+                }
+            }
+
+            var next = new ArrayList<PlanPhotos>();
+            var incomingIds = new HashSet<Long>();
+
+            for (int i = 0; i < req.photos().size(); i++) {
+                var it = req.photos().get(i);
+                Integer orderNo = (it.orderNo() != null) ? it.orderNo() : i;
+
+                if (it.photoId() != null) {
+                    // 기존 엔티티 수정: 도메인 메서드 사용 (세터 금지)
+                    PlanPhotos existing = currentById.get(it.photoId());
+                    if (existing == null) {
+                        throw new IllegalArgumentException("photoId not found for this plan: " + it.photoId());
+                    }
+                    existing.updateAttributes(it.url(), orderNo, it.width(), it.height());
+                    next.add(existing);
+                    incomingIds.add(existing.getPlanPhotoId());
+                } else {
+                    // 신규 추가: 정적 팩토리 사용 (세터/빌더 체인 금지)
+                    if (it.url() == null || it.url().isBlank()) {
+                        throw new IllegalArgumentException("New photo requires non-empty url");
+                    }
+                    PlanPhotos created = PlanPhotos.create(p, it.url(), orderNo, it.width(), it.height());
+                    next.add(created);
+                }
+            }
+
+            // 삭제 대상 산출: 기존 - (요청에 포함된 photoId)
+            List<PlanPhotos> toDelete = current.stream()
+                    .filter(ph -> ph.getPlanPhotoId() != null && !incomingIds.contains(ph.getPlanPhotoId()))
+                    .toList();
+            if (!toDelete.isEmpty()) {
+                planPhotoRepository.deleteAll(toDelete);
+            }
+
+            // 신규만 선별
+            List<PlanPhotos> toInsert = next.stream()
+                    .filter(ph -> ph.getPlanPhotoId() == null)
+                    .toList();
+
+            // ✅ 방어: plan 누락 시 즉시 실패 (DB까지 안 가게)
+            toInsert.forEach(ph -> {
+                if (ph.getPlan() == null) {
+                    throw new IllegalStateException("PlanPhoto.plan is null (check PlanPhotos.create)");
+                }
+            });
+
+            if (!toInsert.isEmpty()) {
+                planPhotoRepository.saveAll(toInsert);
+            }
+            // 기존 수정분은 JPA dirty checking으로 처리됨
+        }
+
+        // 최신 사진 포함 응답
+        List<PlanPhotos> photos =
+                planPhotoRepository.findByPlan_PlanIdOrderByOrderNoAscPlanPhotoIdAsc(planId);
+
+        return toResponse(p, photos);
     }
+
+//    @Transactional
+//    public DetailPlanResponse update(UserPrincipal userPrincipal, Long planId, DetailPlanUpdateRequest req) {
+//        Plans p = planRepository.findDetailByOwner(userPrincipal.getId(), planId)
+//                .orElseThrow(() -> new ResourceNotFoundException("Plans", "planId/userId", planId + "/" + userPrincipal.getId()));
+//
+//        if (p.isDeleted()) throw new ResourceNotFoundException("Plans", "planId", planId);
+//        if (req.startTime() != null && req.endTime() != null && req.startTime().isAfter(req.endTime()))
+//            throw new IllegalArgumentException("startTime must be before endTime");
+//
+//        if (req.privacyLevel() != null) {
+//            String normalized = req.privacyLevel().trim().toUpperCase();
+//            if (!PRIVACY_ALLOWED.contains(normalized)) {
+//                throw new IllegalArgumentException("privacyLevel must be one of " + PRIVACY_ALLOWED);
+//            }
+//
+//            req = new DetailPlanUpdateRequest(
+//                    req.title(), req.content(), req.imageUrl(), req.place(),
+//                    req.startTime(), req.endTime(), req.isCompleted(),
+//                    req.hasSavingsGoal(), req.savingsAmount(), normalized
+//            );
+//        }
+//
+//        p.applyUpdate(req, LocalDateTime.now());
+//
+//        // 업데이트 후에도 사진 포함해 응답
+//        List<PlanPhotos> photos = planPhotoRepository
+//                .findByPlan_PlanIdOrderByOrderNoAscPlanPhotoIdAsc(planId);
+//
+//        return toResponse(p, photos);
+//    }
 
     @Transactional
     public void delete(UserPrincipal userPrincipal, Long planId) {
@@ -71,7 +188,24 @@ public class DetailPlanService {
         p.softDelete(LocalDateTime.now());
     }
 
-    private DetailPlanResponse toResponse(Plans p) {
+    private DetailPlanResponse toResponse(Plans p, List<PlanPhotos> photos) {
+        // 대표 이미지가 비어있으면 첫 번째 사진으로 대체(선택)
+        String imageUrl = p.getImageUrl();
+        if (imageUrl == null && photos != null && !photos.isEmpty()) {
+            imageUrl = photos.get(0).getPhotoUrl();
+        }
+
+        List<DetailPlanResponse.PhotoDto> photoDtos = photos == null ? List.of() :
+                photos.stream()
+                        .map(ph -> new DetailPlanResponse.PhotoDto(
+                                ph.getPlanPhotoId(),
+                                ph.getPhotoUrl(),
+                                ph.getOrderNo(),
+                                ph.getWidth(),
+                                ph.getHeight()
+                        ))
+                        .toList();
+
         return new DetailPlanResponse(
                 p.getPlanId(),
                 p.getUser().getId(),
@@ -86,7 +220,8 @@ public class DetailPlanService {
                 p.isHasSavingsGoal(),
                 p.getSavingsAmount(),
                 p.getPrivacyLevel(), // "PUBLIC" / "PRIVATE"
-                p.getCommentCount() == null ? 0 : p.getCommentCount()
+                p.getCommentCount() == null ? 0 : p.getCommentCount(),
+                photoDtos
         );
     }
 

--- a/server/src/main/java/shinhan/mohaemoyong/server/service/PlanService.java
+++ b/server/src/main/java/shinhan/mohaemoyong/server/service/PlanService.java
@@ -115,6 +115,7 @@ public class PlanService {
     // Entity를 DTO로 변환하는 private 헬퍼 메서드
     private DetailPlanResponse ToDTODetailPlanResponse(Plans plan) {
         User author = plan.getUser(); // 가독성을 위해 작성자 변수 할당
+
         return new DetailPlanResponse(
                 plan.getPlanId(),
                 author.getId(),
@@ -129,7 +130,8 @@ public class PlanService {
                 plan.isHasSavingsGoal(),
                 plan.getSavingsAmount(),
                 plan.getPrivacyLevel(),
-                plan.getCommentCount()
+                plan.getCommentCount(),
+                List.of() // ⬅ photos 빈 리스트로 급한 처리
         );
     }
 }


### PR DESCRIPTION
## 📌관련 이슈
- closed: #88

## 💥작업 내용
- 단일 업로드 로직을 다중 미디어 업로드 로직으로 수정
- DTO/엔티티에 리스트 형태 필드 추가
- 업로드 순서(orderNo) 저장 및 검증 로직 반영
- Service/Controller 요청·응답 스펙 업데이트

## ✨참고 사항
- 기존 단일 업로드 로직은 하위 호환 여부 검토 필요