### PR TITLE
modify : 일정 추가 api 수정

### DIFF
--- a/server/src/main/java/shinhan/mohaemoyong/server/domain/Plans.java
+++ b/server/src/main/java/shinhan/mohaemoyong/server/domain/Plans.java
@@ -51,9 +51,11 @@ public class Plans {
     @Column(name = "place", length = 255)
     private String place;
 
+    @Builder.Default
     @Column(name = "is_completed", nullable = false)
     private boolean isCompleted = false;
 
+    @Builder.Default
     @Column(name = "has_savings_goal", nullable = false)
     private boolean hasSavingsGoal = false;
 
@@ -67,9 +69,11 @@ public class Plans {
     private String withdrawAccountNo;
 
     // enum 대신 문자열
+    @Builder.Default
     @Column(name = "privacy_level", nullable = false, length = 255)
     private String privacyLevel = "PUBLIC";
 
+    @Builder.Default
     @Column(name = "comment_count")
     private Integer commentCount = 0;
 
@@ -84,19 +88,28 @@ public class Plans {
     @Column(name = "deleted_at")
     private LocalDateTime deletedAt;
 
+    @Column(name = "series_id", length = 36)
+    private String seriesId;              // 같은 반복 묶음이면 동일 UUID
+
+    @Column(name = "occurrence_index")
+    private Integer occurrenceIndex;      // 0부터 시작
+
     /** Plans(1) ↔ PlanPhotos(N) */
+    @Builder.Default
     @OneToMany(mappedBy = "plan",
             cascade = CascadeType.ALL,
             orphanRemoval = true)
     private List<PlanPhotos> photos = new ArrayList<>();
 
     /** Plans(1) ↔ PlanParticipants(N) */
+    @Builder.Default
     @OneToMany(mappedBy = "plan",
             cascade = CascadeType.ALL,
             orphanRemoval = true)
     private List<PlanParticipants> participants = new ArrayList<>();
 
     /** Plans(1) ↔ Comments(N) */
+    @Builder.Default
     @OneToMany(mappedBy = "plan",
             cascade = CascadeType.ALL,
             orphanRemoval = true)
@@ -106,10 +119,15 @@ public class Plans {
     void setUserInternal(User user) { this.user = user; }
 
     // 내부 전용 편의 메서드
-    void addPhoto(PlanPhotos photo) {
-        photos.add(photo);
-        if (photo.getPlan() != this) photo.setPlanInternal(this);
+    public void addPhoto(PlanPhotos photo) {
+        if (!photos.contains(photo)) {
+            photos.add(photo);
+            if (photo.getPlan() != this) {
+                photo.setPlanInternal(this);
+            }
+        }
     }
+
 
     public void addParticipant(PlanParticipants pp) {
         // 중복 방지

--- a/server/src/main/java/shinhan/mohaemoyong/server/dto/CreatedPlanItem.java
+++ b/server/src/main/java/shinhan/mohaemoyong/server/dto/CreatedPlanItem.java
@@ -1,0 +1,13 @@
+// shinhan.mohaemoyong.server.dto.CreatedPlanItem.java
+package shinhan.mohaemoyong.server.dto;
+
+import java.time.LocalDateTime;
+
+public record CreatedPlanItem(
+        Long planId,
+        Integer occurrenceIndex,      // 단일 생성이면 null
+        String title,
+        String place,
+        LocalDateTime startTime,
+        LocalDateTime endTime
+) {}

--- a/server/src/main/java/shinhan/mohaemoyong/server/dto/PlanCreateRequest.java
+++ b/server/src/main/java/shinhan/mohaemoyong/server/dto/PlanCreateRequest.java
@@ -14,7 +14,8 @@ public record PlanCreateRequest(
         @NotBlank String title,
         String content,
         String place,
-        String imageUrl,
+
+        String imageUrl,                       // ✅ 대표 이미지 (썸네일)
 
         @NotNull LocalDateTime startTime,
         @NotNull LocalDateTime endTime,
@@ -24,5 +25,7 @@ public record PlanCreateRequest(
 
         List<Long> participantIds,             // GROUP일 때만 사용
 
-        @Valid RecurrenceCreateReq recurrence  // 반복 정보 (없으면 null)
+        @Valid RecurrenceCreateReq recurrence, // 반복 정보 (없으면 null)
+
+        List<String> photos                    // ✅ 나머지 사진들 (여러 장)
 ) {}

--- a/server/src/main/java/shinhan/mohaemoyong/server/dto/PlanCreateResponse.java
+++ b/server/src/main/java/shinhan/mohaemoyong/server/dto/PlanCreateResponse.java
@@ -4,6 +4,7 @@ import java.time.LocalDateTime;
 import java.util.List;
 
 public record PlanCreateResponse(
+        // ── 기존 단일용 필드 (그대로 유지) ─────────────────────────────
         Long planId,
         String title,
         String content,
@@ -15,6 +16,11 @@ public record PlanCreateResponse(
         Integer savingsAmount,
         String imageUrl,
         List<Long> participantIds,
-        List<String> photos,           // ✅ 여러 장 사진 지원
-        RecurrenceCreateReq recurrence // ✅ 반복 정보
+        List<String> photos,
+        RecurrenceCreateReq recurrence,
+
+        String seriesId,                  // 단일 생성이면 null
+        Integer createdCount,             // 생성된 일정 개수
+        List<Long> planIds,               // 생성된 모든 planId
+        List<CreatedPlanItem> items       // 생성된 일정 요약
 ) {}

--- a/server/src/main/java/shinhan/mohaemoyong/server/repository/FriendshipRepository.java
+++ b/server/src/main/java/shinhan/mohaemoyong/server/repository/FriendshipRepository.java
@@ -24,6 +24,14 @@ public interface FriendshipRepository extends JpaRepository<Friendship, Long> {
             "(f.user = :friend AND f.friend = :user)")
     void deletePair(User user, User friend);
 
+
+    @Query("""
+        select (count(f) > 0) from Friendship f
+         where f.user.id = :a and f.friend.id = :b
+    """)
+    boolean existsEdge(@Param("a") Long a, @Param("b") Long b);
+
+
     @Query("""
         select case when count(f) > 0 then true else false end
           from Friendship f

--- a/server/src/main/java/shinhan/mohaemoyong/server/service/PlanService.java
+++ b/server/src/main/java/shinhan/mohaemoyong/server/service/PlanService.java
@@ -3,17 +3,17 @@ package shinhan.mohaemoyong.server.service;
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import shinhan.mohaemoyong.server.domain.PlanPhotos;
 import shinhan.mohaemoyong.server.domain.Plans;
 import shinhan.mohaemoyong.server.domain.PlanParticipants;
 import shinhan.mohaemoyong.server.domain.User;
 import shinhan.mohaemoyong.server.dto.*;
+import shinhan.mohaemoyong.server.repository.FriendshipRepository;
 import shinhan.mohaemoyong.server.repository.PlanRepository;
 import shinhan.mohaemoyong.server.repository.UserRepository;
 
 import java.time.LocalDateTime;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Set;
+import java.util.*;
 import java.util.stream.Collectors;
 import java.time.LocalDate;
 
@@ -23,14 +23,13 @@ public class PlanService {
 
     private final PlanRepository planRepository;
     private final UserRepository userRepository;
+    private final FriendshipRepository friendshipRepository;
 
     @Transactional
     public PlanCreateResponse createPlan(Long creatorId, PlanCreateRequest req) {
-        // 1. 생성자 조회
         User creator = userRepository.findById(creatorId)
                 .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 사용자입니다."));
 
-        // 2. 기본 검증
         if (req.startTime().isAfter(req.endTime())) {
             throw new IllegalArgumentException("시작 시간이 종료 시간보다 늦을 수 없습니다.");
         }
@@ -41,85 +40,216 @@ public class PlanService {
             throw new IllegalArgumentException("단체 일정은 초대할 참여자가 필요합니다.");
         }
 
-        // 3. 일정 엔티티 생성
-        Plans plan = Plans.builder()
-                .user(creator)   // 생성자(작성자)
-                .title(req.title())
-                .content(req.content())
-                .imageUrl(req.imageUrl())
-                .place(req.place())
-                .startTime(req.startTime())
-                .endTime(req.endTime())
-                .hasSavingsGoal(Boolean.TRUE.equals(req.hasSavingsGoal()))
-                .savingsAmount(req.savingsAmount())
-                .privacyLevel(req.privacyLevel().name())
-                .isCompleted(false)   // 기본값
-                .commentCount(0)      // 기본값
-                .build();
-
-
-        // 4. 저장
-        planRepository.save(plan);
-
-        // 5. 단체 일정 처리
+        // --- 그룹/친구 상호 검증 ---
+        Set<Long> participantIds = new HashSet<>();
         if (req.type() == PlanType.GROUP) {
-            // 중복 방지를 위해 Set 사용
-            Set<Long> ids = new HashSet<>(req.participantIds());
-            ids.add(creatorId); // 생성자 자동 포함
-            for (Long pid : ids) {
-                User participant = userRepository.findById(pid)
-                        .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 사용자 ID: " + pid));
-                PlanParticipants pp = PlanParticipants.builder()
-                        .plan(plan)
-                        .user(participant)
-                        .role("member")   // 안 넣으면 기본값 그대로
-                        .build();
-
-                plan.addParticipant(pp); // Plans 엔티티에서 participants 리스트 관리
-
+            participantIds.addAll(req.participantIds());
+            participantIds.remove(creatorId); // 중복 방지
+            List<Long> notFriends = participantIds.stream()
+                    .filter(pid -> !(friendshipRepository.existsEdge(creatorId, pid)
+                            && friendshipRepository.existsEdge(pid, creatorId)))
+                    .toList();
+            if (!notFriends.isEmpty()) {
+                throw new IllegalArgumentException("서로 친구가 아닌 사용자가 포함되어 있습니다: " + notFriends);
             }
         }
 
-        // (TODO: RecurrenceCreateReq 반복 일정 처리 추가)
+        // --- 반복 전개 목록 만들기 ---
+        List<Occurrence> occs = buildOccurrences(req.startTime(), req.endTime(), req.recurrence());
+        final String seriesId = (occs.size() > 1 ? UUID.randomUUID().toString() : null);
 
-        // 6. 응답 생성
+        // --- 저장 (각 occurrence마다 개별 plan row 생성) ---
+        List<Plans> created = new ArrayList<>(occs.size());
+        for (int i = 0; i < occs.size(); i++) {
+            Occurrence oc = occs.get(i);
+
+            Plans plan = Plans.builder()
+                    .user(creator)
+                    .title(req.title())
+                    .content(req.content())
+                    .imageUrl(req.imageUrl())   // ✅ 대표 이미지
+                    .place(req.place())
+                    .startTime(oc.start)
+                    .endTime(oc.end)
+                    .hasSavingsGoal(Boolean.TRUE.equals(req.hasSavingsGoal()))
+                    .savingsAmount(req.savingsAmount())
+                    .privacyLevel(req.privacyLevel().name())
+                    .isCompleted(false)
+                    .commentCount(0)
+                    .seriesId(seriesId)
+                    .occurrenceIndex(seriesId == null ? null : i)
+                    .build();
+
+            // ✅ 나머지 사진 저장
+            if (req.photos() != null && !req.photos().isEmpty()) {
+                int order = 1;
+                for (String url : req.photos()) {
+                    // imageUrl과 중복되는 건 제외 (대표 이미지는 따로 관리)
+                    if (req.imageUrl() != null && req.imageUrl().equals(url)) continue;
+
+                    plan.addPhoto(PlanPhotos.create(plan, url, order++, null, null));
+                }
+            }
+
+
+            if (req.type() == PlanType.GROUP) {
+                Set<Long> all = new HashSet<>(participantIds);
+                all.add(creatorId);
+                for (Long uid : all) {
+                    User u = (uid.equals(creatorId)) ? creator
+                            : userRepository.findById(uid)
+                            .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 사용자 ID: " + uid));
+                    PlanParticipants pp = PlanParticipants.builder()
+                            .plan(plan)
+                            .user(u)
+                            .role("member")
+                            .build();
+                    plan.addParticipant(pp);
+                }
+            }
+
+            planRepository.save(plan);
+            created.add(plan);
+        }
+
+        // --- 응답 생성 ---
+        List<Long> planIds = created.stream()
+                .map(Plans::getPlanId)
+                .toList();
+
+        List<CreatedPlanItem> items = created.stream()
+                .map(p -> new CreatedPlanItem(
+                        p.getPlanId(),
+                        p.getOccurrenceIndex(),
+                        p.getTitle(),
+                        p.getPlace(),
+                        p.getStartTime(),
+                        p.getEndTime()
+                ))
+                .toList();
+
+        Plans first = created.get(0);
         return new PlanCreateResponse(
-                plan.getPlanId(),
-                plan.getTitle(),
-                plan.getContent(),
-                plan.getPlace(),
-                plan.getStartTime(),
-                plan.getEndTime(),
+                first.getPlanId(),
+                first.getTitle(),
+                first.getContent(),
+                first.getPlace(),
+                first.getStartTime(),
+                first.getEndTime(),
                 req.privacyLevel(),
-                plan.isHasSavingsGoal(),
-                plan.getSavingsAmount(),
-                plan.getImageUrl(),         // ✅ imageUrl 추가
-                req.participantIds(),       // ✅ 그룹일 경우만 값 존재
-                List.of(),                  // ✅ photos (추후 확장: plan.getPhotos() 매핑)
-                req.recurrence()            // ✅ 반복 정보 그대로 echo-back
+                first.isHasSavingsGoal(),
+                first.getSavingsAmount(),
+                first.getImageUrl(),
+                req.participantIds(),
+                first.getPhotos().stream()
+                        .map(PlanPhotos::getPhotoUrl)
+                        .toList(),
+                req.recurrence(),
+                seriesId,
+                created.size(),
+                planIds,
+                items
         );
-
     }
 
-    public List<DetailPlanResponse> selectPlansByDate(LocalDate date){
+    /* --------------------------------- */
+    /* 반복 전개 유틸                      */
+    /* --------------------------------- */
+    private record Occurrence(LocalDateTime start, LocalDateTime end) {}
+
+    private List<Occurrence> buildOccurrences(LocalDateTime start, LocalDateTime end, RecurrenceCreateReq r) {
+        List<Occurrence> out = new ArrayList<>();
+        if (r == null || !Boolean.TRUE.equals(r.enabled()) || r.count() == null || r.count() <= 1) {
+            out.add(new Occurrence(start, end));
+            return out;
+        }
+
+        final int count = r.count();
+        final int interval = (r.interval() == null || r.interval() < 1) ? 1 : r.interval();
+        final java.time.Duration dur = java.time.Duration.between(start, end);
+        final String freq = (r.freq() == null) ? "DAILY" : r.freq().toUpperCase();
+
+        switch (freq) {
+            case "DAILY" -> {
+                for (int i = 0; i < count; i++) {
+                    LocalDateTime s = start.plusDays((long) i * interval);
+                    out.add(new Occurrence(s, s.plus(dur)));
+                }
+            }
+            case "WEEKLY" -> {
+                List<java.time.DayOfWeek> order = weeklyOrder(r, start);
+                int generated = 0;
+                int weekBlock = 0;
+                while (generated < count) {
+                    LocalDate baseMonday = start.toLocalDate()
+                            .with(java.time.temporal.TemporalAdjusters.previousOrSame(java.time.DayOfWeek.MONDAY))
+                            .plusWeeks((long) weekBlock * interval);
+                    for (java.time.DayOfWeek dow : order) {
+                        LocalDate candidate = baseMonday.with(java.time.temporal.TemporalAdjusters.nextOrSame(dow));
+                        if (weekBlock == 0 && candidate.isBefore(start.toLocalDate())) continue;
+                        LocalDateTime s = LocalDateTime.of(candidate, start.toLocalTime());
+                        out.add(new Occurrence(s, s.plus(dur)));
+                        generated++;
+                        if (generated >= count) break;
+                    }
+                    weekBlock++;
+                }
+            }
+            case "MONTHLY" -> {
+                for (int i = 0; i < count; i++) {
+                    LocalDateTime s = start.plusMonths((long) i * interval);
+                    out.add(new Occurrence(s, s.plus(dur)));
+                }
+            }
+            default -> throw new IllegalArgumentException("지원하지 않는 반복 주기: " + freq);
+        }
+        return out;
+    }
+
+    private List<java.time.DayOfWeek> weeklyOrder(RecurrenceCreateReq r, LocalDateTime start) {
+        if (r.byDays() == null || r.byDays().isEmpty()) {
+            return List.of(start.getDayOfWeek());
+        }
+        Map<String, java.time.DayOfWeek> map = Map.of(
+                "MO", java.time.DayOfWeek.MONDAY,
+                "TU", java.time.DayOfWeek.TUESDAY,
+                "WE", java.time.DayOfWeek.WEDNESDAY,
+                "TH", java.time.DayOfWeek.THURSDAY,
+                "FR", java.time.DayOfWeek.FRIDAY,
+                "SA", java.time.DayOfWeek.SATURDAY,
+                "SU", java.time.DayOfWeek.SUNDAY
+        );
+        List<java.time.DayOfWeek> ordered = new ArrayList<>();
+        List<java.time.DayOfWeek> weekOrder = List.of(
+                java.time.DayOfWeek.MONDAY, java.time.DayOfWeek.TUESDAY, java.time.DayOfWeek.WEDNESDAY,
+                java.time.DayOfWeek.THURSDAY, java.time.DayOfWeek.FRIDAY, java.time.DayOfWeek.SATURDAY,
+                java.time.DayOfWeek.SUNDAY
+        );
+        for (java.time.DayOfWeek d : weekOrder) {
+            for (String s : r.byDays()) {
+                java.time.DayOfWeek m = map.get(s.toUpperCase());
+                if (m == d) ordered.add(m);
+            }
+        }
+        if (ordered.isEmpty()) ordered = weekOrder;
+        return ordered;
+    }
+
+    public List<DetailPlanResponse> selectPlansByDate(LocalDate date) {
         LocalDateTime startOfDay = date.atStartOfDay();
         LocalDateTime endOfDay = date.atTime(23, 59, 59);
-
         List<Plans> foundPlans = planRepository.findPlansByDateRangeWithUser(startOfDay, endOfDay);
-
         return foundPlans.stream()
-                .map(this::ToDTODetailPlanResponse) // DTO 변환 로직을 별도 메서드로 추출
+                .map(this::ToDTODetailPlanResponse)
                 .collect(Collectors.toList());
     }
 
-    // Entity를 DTO로 변환하는 private 헬퍼 메서드
     private DetailPlanResponse ToDTODetailPlanResponse(Plans plan) {
-        User author = plan.getUser(); // 가독성을 위해 작성자 변수 할당
-
+        User author = plan.getUser();
         return new DetailPlanResponse(
                 plan.getPlanId(),
                 author.getId(),
-                author.getName(), // User 엔티티에서 이름 가져오기
+                author.getName(),
                 plan.getTitle(),
                 plan.getContent(),
                 plan.getImageUrl(),
@@ -131,7 +261,7 @@ public class PlanService {
                 plan.getSavingsAmount(),
                 plan.getPrivacyLevel(),
                 plan.getCommentCount(),
-                List.of() // ⬅ photos 빈 리스트로 급한 처리
+                List.of()
         );
     }
 }


### PR DESCRIPTION
## 📌관련 이슈
- closed: #90 

## 💥작업 내용
- 일정 추가 API에 반복 일정 처리 로직 추가 (seriesId, occurrenceIndex 관리)
- 그룹 일정 추가 시 친구 관계 검증 로직 적용 (양방향 친구만 참여 가능)
- 대표 이미지(imageUrl)와 추가 사진(plan_photos) 분리 저장 로직 추가
- PlanCreateResponse 확장: 반복 결과(planIds, items), 추가 사진 목록 반환

## ✨참고 사항
- 반복 일정은 count/freq/byDays 기준으로 개별 Plan row 생성
- photos는 PlanPhotos 테이블에 저장, imageUrl은 대표 사진 전용

