### PR TITLE
refactor : 수신자 정보 추가

### DIFF
--- a/server/src/main/java/shinhan/mohaemoyong/server/dto/FriendRequestResponse.java
+++ b/server/src/main/java/shinhan/mohaemoyong/server/dto/FriendRequestResponse.java
@@ -18,6 +18,8 @@ public class FriendRequestResponse {
     private String requesterName;
     private Long receiverId;
     private String receiverName;
+    private String receiverImgUrl;
+    private String receiverEmail;
     private String status;
     private String message;
     private Instant createdAt;
@@ -40,6 +42,8 @@ public class FriendRequestResponse {
                 .requesterName(r.getRequester().getName())
                 .receiverId(r.getReceiver().getId())
                 .receiverName(r.getReceiver().getName())
+                .receiverImgUrl(r.getReceiver().getImageUrl())
+                .receiverEmail(r.getReceiver().getEmail())
                 .status(r.getStatus().name())
                 .message(r.getMessage())
                 .createdAt(r.getCreatedAt())


### PR DESCRIPTION
## 📌관련 이슈
- closed: #109

## 💥작업 내용
- FriendRequestResponse DTO에 `receiverImgUrl`, `receiverEmail` 필드 추가
- `fromEntity` 매핑 로직에 수신자 이미지/이메일 정보 포함하도록 수정
- 컨트롤러/서비스 응답 시 새로운 필드가 내려가도록 반영

## ✨참고 사항
- 기존 응답 스펙에 필드 2개가 추가되었으므로 클라이언트에서 파싱 시 유의 필요

