### PR TITLE
Feature/#137 1원 송금 인증 시스템

### DIFF
--- a/server/src/main/java/shinhan/mohaemoyong/server/adapter/deposit/dto/request/AuthCodeRequest.java
+++ b/server/src/main/java/shinhan/mohaemoyong/server/adapter/deposit/dto/request/AuthCodeRequest.java
@@ -1,0 +1,18 @@
+// adapter/deposit/dto/request/RequestAuthCodeRequest.java
+package shinhan.mohaemoyong.server.adapter.deposit.dto.request;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import shinhan.mohaemoyong.server.adapter.common.headerDto.RequestHeader;
+
+@Getter
+@AllArgsConstructor
+public class AuthCodeRequest {
+
+    @JsonProperty("Header")
+    private RequestHeader Header;
+
+    private String accountNo;
+    private String authText;
+}

--- a/server/src/main/java/shinhan/mohaemoyong/server/adapter/deposit/dto/request/CheckAuthCodeRequest.java
+++ b/server/src/main/java/shinhan/mohaemoyong/server/adapter/deposit/dto/request/CheckAuthCodeRequest.java
@@ -1,0 +1,31 @@
+package shinhan.mohaemoyong.server.adapter.deposit.dto.request;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import shinhan.mohaemoyong.server.adapter.common.headerDto.RequestHeader;
+
+@Getter
+@AllArgsConstructor
+public class CheckAuthCodeRequest {
+
+    /**
+     * 공통 헤더
+     */
+    @JsonProperty("Header")
+    private RequestHeader Header;
+
+    /**
+     * 인증할 계좌 번호
+     */
+    private String accountNo;
+
+    /**
+     */
+    private String authText;
+
+    /**
+     * 사용자가 입력한 인증 코드
+     */
+    private String authCode;
+}

--- a/server/src/main/java/shinhan/mohaemoyong/server/adapter/deposit/dto/response/CheckAuthCodeResponse.java
+++ b/server/src/main/java/shinhan/mohaemoyong/server/adapter/deposit/dto/response/CheckAuthCodeResponse.java
@@ -1,0 +1,22 @@
+// adapter/deposit/dto/response/CheckAuthCodeResponse.java
+package shinhan.mohaemoyong.server.adapter.deposit.dto.response;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Getter;
+import shinhan.mohaemoyong.server.adapter.common.headerDto.ResponseHeader;
+
+@Getter
+public class CheckAuthCodeResponse {
+    @JsonProperty("Header")
+    private ResponseHeader Header;
+
+    @JsonProperty("REC")
+    private REC REC;
+
+    @Getter
+    public static class REC {
+        private String status;
+        private String transactionUniqueNo;
+        private String accountNo;
+    }
+}

--- a/server/src/main/java/shinhan/mohaemoyong/server/adapter/deposit/dto/response/OpenAccountAuthResponse.java
+++ b/server/src/main/java/shinhan/mohaemoyong/server/adapter/deposit/dto/response/OpenAccountAuthResponse.java
@@ -1,0 +1,10 @@
+package shinhan.mohaemoyong.server.adapter.deposit.dto.response;
+
+import lombok.Getter;
+import shinhan.mohaemoyong.server.adapter.common.headerDto.ResponseHeader;
+
+@Getter
+public class OpenAccountAuthResponse {
+    private ResponseHeader Header;
+    // openAccountAuth API는 성공 시 별도의 데이터 필드가 없으므로 헤더만 정의합니다.
+}

--- a/server/src/main/java/shinhan/mohaemoyong/server/controller/OneWonAuthController.java
+++ b/server/src/main/java/shinhan/mohaemoyong/server/controller/OneWonAuthController.java
@@ -1,0 +1,31 @@
+package shinhan.mohaemoyong.server.controller;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+import shinhan.mohaemoyong.server.dto.AccountNoRequest;
+import shinhan.mohaemoyong.server.oauth2.security.CurrentUser;
+import shinhan.mohaemoyong.server.oauth2.security.UserPrincipal;
+import shinhan.mohaemoyong.server.service.OneWonAuthService;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/account")
+public class OneWonAuthController {
+    private final OneWonAuthService oneWonAuthService;
+
+    @PostMapping("/api/v1/account/auth/call")
+    public ResponseEntity<?> oneWonAuthCall(@CurrentUser UserPrincipal userPrincipal,
+                                            @RequestBody AccountNoRequest request) {
+        oneWonAuthService.oneWonAuthCall(userPrincipal, request);
+        return new ResponseEntity<>("해당 계좌로 1원을 송금하였씁니다, 거래 내역에서 인증코드를 확인하시길 바랍니다.", HttpStatus.ACCEPTED);
+    }
+
+    @PostMapping("/api/v1/account/auth")
+    public ResponseEntity<?> oneWonAuth(@CurrentUser UserPrincipal userPrincipal,
+                                        @RequestBody AccountNoRequest request) {
+        oneWonAuthService.oneWonAuth(userPrincipal, request);
+        return new ResponseEntity<>("인증에 성공하였습니다.", HttpStatus.OK);
+    }
+}

--- a/server/src/main/java/shinhan/mohaemoyong/server/domain/Accounts.java
+++ b/server/src/main/java/shinhan/mohaemoyong/server/domain/Accounts.java
@@ -61,10 +61,17 @@ public class Accounts {
     @Column(name = "authenticated", nullable = false, columnDefinition = "BOOLEAN DEFAULT false")
     private Boolean authenticated = false;
 
+    @Column(name = "isAuthCalled", nullable = false, columnDefinition = "BOOLEAN DEFAULT false")
+    private Boolean isAuthCalled = false;
+
     // 내부 전용
     void setUserInternal(User user) { this.user = user; }
 
     public void updateTargetAmount(Long targetAmount) { this.targetAmount = targetAmount; }
 
     public void updateAlias(String alias) { this.accountName = alias; }
+
+    public void updateIsAuthCalled() {
+        this.isAuthCalled = true;
+    }
 }

--- a/server/src/main/java/shinhan/mohaemoyong/server/domain/Accounts.java
+++ b/server/src/main/java/shinhan/mohaemoyong/server/domain/Accounts.java
@@ -71,7 +71,7 @@ public class Accounts {
 
     public void updateAlias(String alias) { this.accountName = alias; }
 
-    public void updateIsAuthCalled() {
-        this.isAuthCalled = true;
-    }
+    public void updateIsAuthCalled() { this.isAuthCalled = true; }
+
+    public void updateAuthenticated() { this.authenticated = true; }
 }

--- a/server/src/main/java/shinhan/mohaemoyong/server/domain/Accounts.java
+++ b/server/src/main/java/shinhan/mohaemoyong/server/domain/Accounts.java
@@ -57,6 +57,10 @@ public class Accounts {
     @Column(name = "updated_at")
     private Instant updatedAt;
 
+    // columnDefinition : 기존에 DB에 저장되어 있던 데이터나, 애플리케이션을 거치지 않고 DB에서 직접 추가된 데이터에 대해서는 기본값을 보장
+    @Column(name = "authenticated", nullable = false, columnDefinition = "BOOLEAN DEFAULT false")
+    private Boolean authenticated = false;
+
     // 내부 전용
     void setUserInternal(User user) { this.user = user; }
 

--- a/server/src/main/java/shinhan/mohaemoyong/server/dto/AccountNoRequest.java
+++ b/server/src/main/java/shinhan/mohaemoyong/server/dto/AccountNoRequest.java
@@ -5,9 +5,9 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
-@Builder
 @Getter @NoArgsConstructor @AllArgsConstructor
 public class AccountNoRequest {
     private String accountNo;
+    private String authCode;
 }
 

--- a/server/src/main/java/shinhan/mohaemoyong/server/dto/SimpleAccountListResponse.java
+++ b/server/src/main/java/shinhan/mohaemoyong/server/dto/SimpleAccountListResponse.java
@@ -11,16 +11,21 @@ public class SimpleAccountListResponse {
     private String accountNo;
     private Long accountBalance;
     private String accountName;
+    private Boolean authenticated;
 
+    // 우리 DB 에서 필요한 데이터는 ourAccount, 금융망 DB 에서 필요한 데이터는 record
     public static SimpleAccountListResponse toDto(InquireDemandDepositAccountListResponse.Record record, Accounts ourAccount) {
-        // 우리 DB에 저장된 계좌 별칭(accountName)이 있다면 그것을 사용하고,
-        // 없다면(null이면) 어댑터에서 받은 계좌명을 예비로 사용
+        // 우리 DB에 저장된 계좌 별칭(accountName)이 있다면 그것을 사용하고, 없다면(null이면) 어댑터에서 받은 계좌명을 예비로 사용
         String finalAccountName = (ourAccount != null) ? ourAccount.getAccountName() : record.getAccountName();
+
+        // 혹시나 우리 DB 에 등록이 되어있지 않은 경우 NullPointerException 방지
+        Boolean finalAuthenticated = (ourAccount != null) ? ourAccount.getAuthenticated() : false;
 
         return SimpleAccountListResponse.builder()
                 .accountNo(record.getAccountNo())
                 .accountBalance(record.getAccountBalance())
                 .accountName(finalAccountName)
+                .authenticated(finalAuthenticated)
                 .build();
     }
 

--- a/server/src/main/java/shinhan/mohaemoyong/server/dto/SimpleAccountListResponse.java
+++ b/server/src/main/java/shinhan/mohaemoyong/server/dto/SimpleAccountListResponse.java
@@ -12,6 +12,7 @@ public class SimpleAccountListResponse {
     private Long accountBalance;
     private String accountName;
     private Boolean authenticated;
+    private Boolean isAuthCalled;
 
     // 우리 DB 에서 필요한 데이터는 ourAccount, 금융망 DB 에서 필요한 데이터는 record
     public static SimpleAccountListResponse toDto(InquireDemandDepositAccountListResponse.Record record, Accounts ourAccount) {
@@ -21,11 +22,15 @@ public class SimpleAccountListResponse {
         // 혹시나 우리 DB 에 등록이 되어있지 않은 경우 NullPointerException 방지
         Boolean finalAuthenticated = (ourAccount != null) ? ourAccount.getAuthenticated() : false;
 
+        // 혹시나 우리 DB 에 등록이 되어있지 않은 경우 NullPointerException 방지
+        Boolean finalIsAuthCalled = (ourAccount != null) ? ourAccount.getIsAuthCalled() : false;
+
         return SimpleAccountListResponse.builder()
                 .accountNo(record.getAccountNo())
                 .accountBalance(record.getAccountBalance())
                 .accountName(finalAccountName)
                 .authenticated(finalAuthenticated)
+                .isAuthCalled(finalIsAuthCalled)
                 .build();
     }
 

--- a/server/src/main/java/shinhan/mohaemoyong/server/exception/GlobalExceptionHandler.java
+++ b/server/src/main/java/shinhan/mohaemoyong/server/exception/GlobalExceptionHandler.java
@@ -13,7 +13,7 @@ import shinhan.mohaemoyong.server.adapter.exception.ExceptionResponseDto;
 public class GlobalExceptionHandler {
 
     @ExceptionHandler(ApiErrorException.class)
-    public ResponseEntity<ExceptionResponseDto> handleApiErrorException(ApiErrorException e) {
+    public ResponseEntity<ExceptionResponseDto> handleApiErrorException(ApiErrorException e) { // 내가 정의한 에러클래스
         log.warn("API 에러 발생: 코드 [{}], 메시지 [{}]", e.getErrorCode(), e.getErrorMessage());
 
         ExceptionResponseDto errorResponse = ExceptionResponseDto.builder()
@@ -28,6 +28,9 @@ public class GlobalExceptionHandler {
                 status = HttpStatus.FORBIDDEN; // 403
                 break;
             case "A1014": // 특정 금융 API 에러
+                status = HttpStatus.BAD_REQUEST; // 400
+                break;
+            case "E002" : // 1원 송금 인증코드 틀림
                 status = HttpStatus.BAD_REQUEST; // 400
                 break;
             default:

--- a/server/src/main/java/shinhan/mohaemoyong/server/repository/AccountRepository.java
+++ b/server/src/main/java/shinhan/mohaemoyong/server/repository/AccountRepository.java
@@ -25,4 +25,6 @@ public interface AccountRepository extends JpaRepository<Accounts, Long> {
 
     Optional<Accounts> findByAccountNumber(String accountNumber);
 
+    Optional<Accounts> findByAccountNumberAndUser(String accountNumber, User user);
+
 }

--- a/server/src/main/java/shinhan/mohaemoyong/server/service/OneWonAuthService.java
+++ b/server/src/main/java/shinhan/mohaemoyong/server/service/OneWonAuthService.java
@@ -1,0 +1,42 @@
+package shinhan.mohaemoyong.server.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import shinhan.mohaemoyong.server.domain.Accounts;
+import shinhan.mohaemoyong.server.domain.User;
+import shinhan.mohaemoyong.server.dto.AccountNoRequest;
+import shinhan.mohaemoyong.server.oauth2.security.UserPrincipal;
+import shinhan.mohaemoyong.server.repository.AccountRepository;
+import shinhan.mohaemoyong.server.repository.UserRepository;
+
+import java.util.Optional;
+
+@Service
+@RequiredArgsConstructor
+public class OneWonAuthService {
+
+    private final AccountRepository accountRepository;
+    private final UserRepository userRepository;
+
+    @Transactional
+    public void oneWonAuthCall(UserPrincipal userPrincipal, AccountNoRequest request) {
+        User user = userRepository.findById(userPrincipal.getId()).orElseThrow(() -> new IllegalArgumentException("[ERROR] 존재하지 않는 사용자입니다."));
+        String accountNo = request.getAccountNo();
+
+
+
+        // 1원 송금 요청 어댑터를 성공적으로 보냈을때
+        Accounts accounts = accountRepository.findByAccountNumberAndUser(accountNo, user).orElseThrow(() -> new IllegalArgumentException("[ERROR] 존재하지 않는 계좌입니다."));
+        accounts.updateIsAuthCalled();
+    }
+
+    @Transactional
+    public void oneWonAuth(UserPrincipal userPrincipal, AccountNoRequest request) {
+        Long userId = userPrincipal.getId();
+        String accountNo = request.getAccountNo();
+        String authCode = request.getAccountNo();
+
+
+    }
+}

--- a/server/src/main/java/shinhan/mohaemoyong/server/service/OneWonAuthService.java
+++ b/server/src/main/java/shinhan/mohaemoyong/server/service/OneWonAuthService.java
@@ -3,6 +3,8 @@ package shinhan.mohaemoyong.server.service;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import shinhan.mohaemoyong.server.adapter.deposit.DemandDepositApiAdapter;
+import shinhan.mohaemoyong.server.adapter.exception.ApiErrorException;
 import shinhan.mohaemoyong.server.domain.Accounts;
 import shinhan.mohaemoyong.server.domain.User;
 import shinhan.mohaemoyong.server.dto.AccountNoRequest;
@@ -10,7 +12,6 @@ import shinhan.mohaemoyong.server.oauth2.security.UserPrincipal;
 import shinhan.mohaemoyong.server.repository.AccountRepository;
 import shinhan.mohaemoyong.server.repository.UserRepository;
 
-import java.util.Optional;
 
 @Service
 @RequiredArgsConstructor
@@ -18,24 +19,40 @@ public class OneWonAuthService {
 
     private final AccountRepository accountRepository;
     private final UserRepository userRepository;
+    private final DemandDepositApiAdapter demandDepositApiAdapter;
 
     @Transactional
     public void oneWonAuthCall(UserPrincipal userPrincipal, AccountNoRequest request) {
         User user = userRepository.findById(userPrincipal.getId()).orElseThrow(() -> new IllegalArgumentException("[ERROR] 존재하지 않는 사용자입니다."));
         String accountNo = request.getAccountNo();
 
+        try {
+            demandDepositApiAdapter.oneWonAuthCall(accountNo);
+        } catch (ApiErrorException e) {
 
+        }
 
-        // 1원 송금 요청 어댑터를 성공적으로 보냈을때
+        // 1원 송금 요청 어댑터가 성공
         Accounts accounts = accountRepository.findByAccountNumberAndUser(accountNo, user).orElseThrow(() -> new IllegalArgumentException("[ERROR] 존재하지 않는 계좌입니다."));
-        accounts.updateIsAuthCalled();
+        accounts.updateIsAuthCalled(); // isAuthCalled = true;
     }
 
     @Transactional
     public void oneWonAuth(UserPrincipal userPrincipal, AccountNoRequest request) {
-        Long userId = userPrincipal.getId();
-        String accountNo = request.getAccountNo();
         String authCode = request.getAccountNo();
+
+        User user = userRepository.findById(userPrincipal.getId()).orElseThrow(() -> new IllegalArgumentException("[ERROR] 존재하지 않는 사용자입니다."));
+        String accountNo = request.getAccountNo();
+
+        try {
+            demandDepositApiAdapter.oneWonAuth(accountNo, authCode);
+        } catch (ApiErrorException e) {
+
+        }
+
+        // 1원 송금 인증 어댑터가 성공
+        Accounts accounts = accountRepository.findByAccountNumberAndUser(accountNo, user).orElseThrow(() -> new IllegalArgumentException("[ERROR] 존재하지 않는 계좌입니다."));
+        accounts.updateAuthenticated(); // authenticated = true;
 
 
     }


### PR DESCRIPTION
## 📌관련 이슈
- closed: #137 

# 아래 설명은 이전 버전이고 1원 송금 API부분은 사용될 예정

## 💥작업 내용
<!-- 이슈에 표기한 작업/수정/추가한 내용등을 적어주세요. -->
- 작업 내용 1
- 설명 : 1원 송금 시스템으로 계좌 불러오기 및 비대면으로 온라인 계좌 개설 시 필요한 내가 그 계좌의 주인(실소유주)이 맞는지를 최종적으로 검증하는 시스템 개발
- 작업 내용 1 : 내 명의의 계좌 불러오기 API
  - 한번에 하나의 계좌를 불러올 수 있고 이는 1원 인증 시스템으로 해결함
  - 그런데 불러올 계좌의 입금내역을 또 우리 앱에서 해야하므로 각 계좌 테이블의 authenticated : Boolean 으로 인증된 것인지를 체크가 가능함 
    - 인증된 계좌 : authenticated : true, 프런트에서 '인증 완료' 라는 표시가 보이게함, 입금계좌 및 출금계좌 선택 시 true여야만 선택되게 처리
    - 인증되지 않은 계좌 : authenticated : false, 프런트에서 '인증 필요' 라는 표시가 보이게함(클릭시 1원 송금 인증), 입금계좌 및 출금계좌 선택 시 '인증이 필요한 계좌입니다' 라는 문구와 함계 선택되지 못하게함 -> 프런트에서 애초에  (postman등으로 악의적으로 api요청을 할 수도 있으니 백엔드 에서도 막음 -> 근데 이건 생각해보니 토큰이 없으면 불가능 해서 제외)
- 작업 내용 2 : 온라인 비대면 계좌 개설 시 필요한 1원 송금 인증 시스템 
  - 백엔드 로직 참고 : 기업명은 우리 앱 인지 분리를 위해 사용되는 default값, application.properties에서 불변값으로 지정하고 사용하므로, 사용자는 인증코드 4자리만 필요함
## ✨참고 사항
### 수정 해야할 API
- Accounts 엔티티 : authenticated 필드 추가
- 계좌 생성 : 생성시 Accounts 테이블의 authenticated 필드도 초기화되게 수정
- 계좌 목록 조회 : 응답에 authenticated 추가

### 프런트엔드 수정해야할 부분
- 계좌 목록조회 스크린의 계좌 표시 : 
  - authenticated 가 true 라면 '인증 완료' 표시
  - authenticated 가 false 일때
    - isAuthCalled 가 false 라면 '인증 필요' 표시
    - isAuthCalled 가 true 라면 '코드 인증' 표시
- 입금계좌, 출금계좌 선택 (계좌 목록조회 스크린) : authenticated 의 T/F 여부에 따라 선택 가능 / 선택 불가능
- '인증 필요' 버튼 클릭 : '1원 송금 인증을 요청하시겠습니까? -> 예 -> '해당 계좌로 1원 송금을 완료하였습니다, 거래내역에서 인증코드를 확인하여 주십시요' -> 이후엔 그 버튼이 '코드 인증' 으로 변환(isAuthCalled = true) -> 계좌 거래내역에서 '인증번호 4자리' 확인 후 -> '코드 인증' 버튼 클릭 -> 코드입력 -> '인증이 완료되었습니다' -> 버튼이 '인증 완료' 로 되고 컬럼의 authenticated가 true로 변환
## ✨참고 사항
- 참고 사항 1


