### PR TITLE
Fix : 친구관계

### DIFF
--- a/server/src/main/java/shinhan/mohaemoyong/server/domain/FriendLastSeen.java
+++ b/server/src/main/java/shinhan/mohaemoyong/server/domain/FriendLastSeen.java
@@ -7,12 +7,6 @@ import lombok.NoArgsConstructor;
 import java.time.LocalDateTime;
 
 @Entity
-@Table(
-        name = "friend_last_seen", // 실제 테이블 이름에 맞게 확인하세요.
-        uniqueConstraints = {
-                @UniqueConstraint(columnNames = {"userId", "friendId"}) // 실제 필드명 확인!
-        }
-)
 @Getter
 @NoArgsConstructor
 public class FriendLastSeen {

--- a/server/src/main/java/shinhan/mohaemoyong/server/domain/FriendLastSeen.java
+++ b/server/src/main/java/shinhan/mohaemoyong/server/domain/FriendLastSeen.java
@@ -7,7 +7,12 @@ import lombok.NoArgsConstructor;
 import java.time.LocalDateTime;
 
 @Entity
-@Table(name = "friend_last_seen")
+@Table(
+        name = "friend_last_seen", // 실제 테이블 이름에 맞게 확인하세요.
+        uniqueConstraints = {
+                @UniqueConstraint(columnNames = {"userId", "friendId"}) // 실제 필드명 확인!
+        }
+)
 @Getter
 @NoArgsConstructor
 public class FriendLastSeen {

--- a/server/src/main/java/shinhan/mohaemoyong/server/repository/FriendLastSeenRepository.java
+++ b/server/src/main/java/shinhan/mohaemoyong/server/repository/FriendLastSeenRepository.java
@@ -7,6 +7,6 @@ import java.util.Optional;
 
 public interface FriendLastSeenRepository extends JpaRepository<FriendLastSeen, Long> {
 
-    Optional<FriendLastSeen> findByUserIdAndFriendId(Long userId, Long friendId);
+    Optional<FriendLastSeen> findFirstByUserIdAndFriendIdOrderByIdDesc(Long userId, Long friendId);
 
 }

--- a/server/src/main/java/shinhan/mohaemoyong/server/service/FriendPlanService.java
+++ b/server/src/main/java/shinhan/mohaemoyong/server/service/FriendPlanService.java
@@ -45,7 +45,7 @@ public class FriendPlanService {
         LocalDateTime until = now.plusDays(7);
 
         LocalDateTime lastSeen = lastSeenRepository
-                .findByUserIdAndFriendId(viewerId, friendId)
+                .findFirstByUserIdAndFriendIdOrderByIdDesc(viewerId, friendId)
                 .map(FriendLastSeen::getLastSeenAt)
                 .orElse(LocalDateTime.of(1970,1,1,0,0));
 
@@ -60,7 +60,7 @@ public class FriendPlanService {
         ensureFriendship(userId, friendId);
 
         FriendLastSeen lastSeen = lastSeenRepository
-                .findByUserIdAndFriendId(userId, friendId)
+                .findFirstByUserIdAndFriendIdOrderByIdDesc(userId, friendId)
                 .orElse(new FriendLastSeen(userId, friendId, LocalDateTime.now()));
 
         lastSeen.updateLastSeen(LocalDateTime.now());
@@ -78,7 +78,7 @@ public class FriendPlanService {
         List<Plans> plans = planRepository.findFriendPublicPlansWithin7Days(friendId, now, until);
 
         LocalDateTime lastSeen = lastSeenRepository
-                .findByUserIdAndFriendId(viewerId, friendId)
+                .findFirstByUserIdAndFriendIdOrderByIdDesc(viewerId, friendId)
                 .map(FriendLastSeen::getLastSeenAt)
                 .orElse(LocalDateTime.of(1970,1,1,0,0));
 
@@ -95,7 +95,7 @@ public class FriendPlanService {
 
         // ✅ 조회 후 자동 seen 처리
         FriendLastSeen entity = lastSeenRepository
-                .findByUserIdAndFriendId(viewerId, friendId)
+                .findFirstByUserIdAndFriendIdOrderByIdDesc(viewerId, friendId)
                 .orElse(new FriendLastSeen(viewerId, friendId, LocalDateTime.of(1970,1,1,0,0)));
         entity.updateLastSeen(LocalDateTime.now(ZONE));
         lastSeenRepository.save(entity);
@@ -123,7 +123,7 @@ public class FriendPlanService {
 
         // ✅ 조회 후 자동 seen 처리
         FriendLastSeen lastSeen = lastSeenRepository
-                .findByUserIdAndFriendId(viewerId, friendId)
+                .findFirstByUserIdAndFriendIdOrderByIdDesc(viewerId, friendId)
                 .orElse(new FriendLastSeen(viewerId, friendId, LocalDateTime.now()));
         lastSeen.updateLastSeen(LocalDateTime.now());
         lastSeenRepository.save(lastSeen);


### PR DESCRIPTION
## 📌관련 이슈
- closed: #141 
## 💥작업 내용
<!-- 이슈에 표기한 작업/수정/추가한 내용등을 적어주세요. -->
- 작업 내용 1 : 우리 로직에선 '마지막에 확인된 친구의 일정' 테이블이 중복된 값을 허용해야 하므로 이를 위해 findByUserIdAndFriend 를
findFirstByUserIdAndFriendIdOrderByIdDesc 로 변환함
- OrderByLastSeenAtDesc 보다 OrderByIdDesc 가 PK 라는 index를 사용하므로 쿼리성능이 훨씬 우수함
## ✨참고 사항
- 참고 사항 1


